### PR TITLE
All the GPT output is being typed backwards

### DIFF
--- a/org-ai-useful.el
+++ b/org-ai-useful.el
@@ -131,7 +131,8 @@ Will always return t if `org-ai-talk-confirm-speech-input' is nil."
                                                   ((plist-get delta 'content)
                                                    (let ((text (plist-get delta 'content)))
                                                      (with-current-buffer output-buffer
-                                                       (goto-char (point-max))
+                                                       (unless (eq (window-buffer) output-buffer)
+                                                         (goto-char (point-max)))
                                                        (insert (decode-coding-string text 'utf-8)))
                                                      (run-hook-with-args 'org-ai-after-chat-insertion-hook 'text text)))
                                                   ((plist-get choice 'finish_reason)

--- a/org-ai-useful.el
+++ b/org-ai-useful.el
@@ -131,6 +131,7 @@ Will always return t if `org-ai-talk-confirm-speech-input' is nil."
                                                   ((plist-get delta 'content)
                                                    (let ((text (plist-get delta 'content)))
                                                      (with-current-buffer output-buffer
+                                                       (goto-char (point-max))
                                                        (insert (decode-coding-string text 'utf-8)))
                                                      (run-hook-with-args 'org-ai-after-chat-insertion-hook 'text text)))
                                                   ((plist-get choice 'finish_reason)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29102529/229368931-a4dba6bb-f06e-4ff0-bcb7-17e3328640d4.png)
It seems like each chunk is being inserted to the beginning of the buffer. I'm using Doom Emacs. 

I've made a patch that fixes this for me.