### PR TITLE
org-ai-on-project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.0] - 2023-04-17
+### Added
+- `org-ai-on-project`: Offers a new method for running prompts and modifying multiple files at once.
+
+### Changed
+- `org-ai-on-region` (and related functions such as `org-ai-refactor`) do not quote user input with "> " anymore as this could be repeated in the output (see [#30](https://github.com/rksm/org-ai/issues/30))
+- `org-ai-on-region` now outputs both prompt and answer into an `org-mode` buffer. This allows to easily edit the answer and re-run the prompt with `C-c C-c` (see [#29](https://github.com/rksm/org-ai/issues/29)). You can customize the variable `org-ai-on-region-file` to specify a file to store the conversations in. E.g. `(setq org-ai-on-region-file (expand-file-name "org-ai-on-region.org" org-directory))`. New prompts will be appended.
+
 ## [0.2.6] - 2023-04-07
 ### Changed
 - Deactivating read-only mode when reusing the `*org-ai-on-region*` buffer. This blocked repeated on-region requests if the buffer was still open.

--- a/org-ai-on-project.el
+++ b/org-ai-on-project.el
@@ -1,0 +1,344 @@
+;;; org-ai-on-project.el --- Run org-ai on multiple files / a project  -*- lexical-binding: t; -*-
+
+;; This file is NOT part of GNU Emacs.
+
+;; org-ai.el is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; org-ai.el is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with org-ai.el.
+;; If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Run org-ai in the scope of a project.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'widget)
+(require 'org-ai-useful)
+
+(eval-when-compile
+  (require 'wid-edit))
+
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; data structures for representing the selected project files
+
+(cl-defstruct org-ai-on-project--state
+  "Entire state of project in the on-project buffer."
+  files
+  base-dir
+  pattern
+  modify-code
+  prompt)
+
+(cl-defstruct org-ai-on-project--file
+  "Represents a selected file choosen to be run on."
+  file
+  full-path
+  region
+  chosen)
+
+(defvar-local org-ai-on-project--current-state nil
+  "Current state of the on-project buffer.")
+
+(defvar org-ai-on-project--buffer-name "*org-ai-on-project*"
+  "Name of the on-project buffer.")
+
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; helpers
+(defun org-ai-on-project--reload ()
+  (when (buffer-live-p (get-buffer org-ai-on-project--buffer-name))
+    (with-current-buffer org-ai-on-project--buffer-name
+      (let ((pos (point)))
+        (org-ai-on-project--render org-ai-on-project--current-state)
+        (goto-char pos)))))
+
+(defun org-ai-on-project--find-files (base-dir patterns)
+  (let* ((default-directory base-dir)
+         (patterns (string-split patterns " " t))
+         (known-project-files (and (fboundp #'projectile-current-project-files)
+                                   (projectile-current-project-files))))
+
+    ;; This is quite a hack here:
+    ;; If we have a pattern like "**/*js", it will only search in subdirectories,
+    ;; not the base directory.
+    ;; This is unlikely what the user want so we will add a pattern without the
+    ;; "**/" prefix like "*js"
+    (setq patterns (append patterns
+                           (cl-loop for pattern in patterns
+                                    with modified-pattern = nil
+                                    when (string-prefix-p "**/" pattern)
+                                    do (setq modified-pattern (string-replace "**/" "" pattern))
+                                    when (not (member modified-pattern patterns))
+                                    collect (string-replace "**/" "" pattern))))
+
+    (cl-loop with found-files = nil
+             for pattern in patterns
+             do (cl-loop for file in (file-expand-wildcards pattern)
+                         when (and (file-regular-p file)
+                                   (or (not known-project-files)
+                                       (member file known-project-files)))
+                         do (push (make-org-ai-on-project--file
+                                   :file file
+                                   :full-path (expand-file-name file base-dir)
+                                   :chosen t)
+                                  found-files))
+             finally return (nreverse found-files))))
+
+(defun org-ai-on-project--get-file-content (file)
+  "Read the content of FILE and return it as a string."
+  (declare (indent 1))
+  (let* ((full-path (org-ai-on-project--file-full-path file))
+          (region (org-ai-on-project--file-region file))
+          (region-start (car region))
+          (region-end (cadr region))
+          start end)
+     (with-temp-buffer
+       (insert-file-contents full-path)
+       (goto-char (or region-start (point-min)))
+       (beginning-of-line)
+       (setq start (point))
+       (goto-char (or region-start (point-max)))
+       (end-of-line)
+       (setq end (point))
+       (buffer-substring-no-properties start end))))
+
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; helper mode and functions for selecting regions in files
+
+(defvar-local org-ai-on-project--select-region-file-already-open nil)
+(defvar-local org-ai-on-project--select-region-file nil
+  "File of type `org-ai-on-project--file` that is currently being selected.")
+
+(define-minor-mode org-ai-on-project--select-region-mode
+  "A mode for temporarily selecting a region in a file."
+  :lighter " Select-Region"
+  :keymap (let ((map (make-sparse-keymap)))
+            (define-key map (kbd "C-c C-c") 'org-ai-on-project--confirm-selection)
+            (define-key map (kbd "C-c k") (lambda () (interactive) (org-ai-on-project--confirm-selection t)))
+            map))
+
+(defun org-ai-on-project--confirm-selection (&optional cancel)
+  "Confirm the selected region and stop `org-ai-on-project--select-region-mode`."
+  (interactive)
+  (when org-ai-on-project--select-region-mode
+    (let ((region (when (and (not cancel) (region-active-p)) (list (region-beginning) (region-end))))
+          (file org-ai-on-project--select-region-file))
+      (message "Selected region: %s" region)
+      (deactivate-mark)
+      (org-ai-on-project--select-region-mode -1)
+      (if org-ai-on-project--select-region-file-already-open
+          (bury-buffer)
+        (kill-this-buffer))
+      (when file (setf (org-ai-on-project--file-region file) region))
+      (org-ai-on-project--reload)
+      (switch-to-buffer org-ai-on-project--buffer-name)
+      (message "...%s" (current-buffer)))))
+
+(defun org-ai-on-project--select-region-in-file (file)
+  "Open FILE and start `org-ai-on-project--select-region-mode` to select a region.
+FILE is of type `org-ai-on-project--file`. It is not a string!"
+  (interactive "fSelect file: ")
+
+  (let* ((file-path (org-ai-on-project--file-full-path file))
+         (buf (if-let ((buf (find-buffer-visiting file-path)))
+                 (with-current-buffer buf
+                   (setq org-ai-on-project--select-region-file-already-open t)
+                   buf)
+               (find-file-literally file-path)
+               (setq org-ai-on-project--select-region-file-already-open nil)
+               (current-buffer))))
+    (with-current-buffer buf
+      (setq org-ai-on-project--select-region-file file)
+      (org-ai-on-project--select-region-mode 1)
+      (message "Select a region then press `C-c C-c'. Cancel with `C-c k'."))))
+
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; "UI" for the on-project buffer
+
+(defmacro with-on-project-buffer (&rest body)
+  `(progn
+     (kill-buffer (get-buffer-create org-ai-on-project--buffer-name))
+     (switch-to-buffer (get-buffer-create org-ai-on-project--buffer-name))
+     (kill-all-local-variables)
+     (with-current-buffer org-ai-on-project--buffer-name
+       ,@body
+       (use-local-map widget-keymap)
+       (widget-setup)
+       (org-ai-on-project-mode 1)
+       (beginning-of-buffer))))
+
+(defun org-ai-on-project--render (state)
+  (let ((base-dir (org-ai-on-project--state-base-dir state))
+        (files (org-ai-on-project--state-files state))
+        (pattern (org-ai-on-project--state-pattern state))
+        (prompt (org-ai-on-project--state-prompt state)))
+
+    (with-on-project-buffer
+      (setq org-ai-on-project--current-state state)
+
+      (widget-insert "On project: " base-dir "\n\n")
+
+      (widget-create 'text
+                     :format "Prompt: %v"
+                     :notify (lambda (widget &rest ignore)
+                               (setf (org-ai-on-project--state-prompt state)
+                                     (widget-value widget)))
+                     (or (org-ai-on-project--state-prompt state) ""))
+
+      (widget-insert "\n\n")
+
+      (widget-create 'editable-field
+		     :size 70
+		     :format "Files: %v " ; Text after the field!
+		     pattern)
+
+      (widget-create 'push-button
+                     :notify (lambda (&rest ignore)
+                               (widget-backward 1)
+                               (let* ((pos (point))
+                                      (pattern (widget-value (widget-at (point))))
+                                      (files (org-ai-on-project--find-files base-dir pattern)))
+                                 (org-ai-on-project--render
+                                  (make-org-ai-on-project--state :files files
+                                                                 :base-dir base-dir
+                                                                 :pattern pattern
+                                                                 :prompt prompt))
+                                 (goto-char pos)))
+                     "Search")
+      (widget-insert "\n\n")
+
+      (cl-loop for file in files
+               do (lexical-let ((file file))
+                    (widget-create 'checkbox
+                                   :notify (lambda (widget &rest ignore)
+                                             (setf (org-ai-on-project--file-chosen file) (widget-value widget)))
+                                   (org-ai-on-project--file-chosen file))
+                    (widget-insert " " (org-ai-on-project--file-file file) " ")
+                    (widget-create 'push-button
+                                   :notify (lambda (&rest ignore)
+                                             (org-ai-on-project--select-region-in-file file))
+                                   (if-let ((region (org-ai-on-project--file-region file)))
+                                       (format "%s-%s" (car region) (cadr region))
+                                     "entire file"))
+                    (widget-insert "\n")))
+
+      (widget-insert "\n\n")
+
+      (widget-insert "Modify code: ")
+      (widget-create 'checkbox
+                     :notify (lambda (widget &rest ignore)
+                               (setf (org-ai-on-project--state-modify-code state)
+                                     (widget-value widget)))
+                     (org-ai-on-project--state-modify-code state))
+
+      (widget-insert "\n\n")
+
+      (widget-create 'push-button
+                     :notify (lambda (&rest ignore)
+                               (org-ai-on-project--run state))
+                     "OK")
+
+      (widget-insert " ")
+
+      (widget-create 'push-button
+                     :notify (lambda (&rest ignore) (kill-buffer))
+                     "Cancel")
+      )))
+
+(defun org-ai-on-project--self-insert-command (N)
+  "Helper for buffer commands."
+  (interactive "p")
+  (if (eq 'editable-field (widget-type (widget-at (point))))
+      (self-insert-command N)
+    (kill-buffer)))
+
+(defvar org-ai-on-project-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "q")
+                (lambda (N)
+                  (interactive "p")
+                  (if (eq 'editable-field (widget-type (widget-at (point))))
+                      (self-insert-command N)
+                    (kill-buffer))))
+    (define-key map (kbd "g")
+                (lambda (N)
+                  (interactive "p")
+                  (if (or (eq 'editable-field (widget-type (widget-at (point))))
+                          (eq 'text (widget-type (widget-at (point)))))
+                      (self-insert-command N)
+                    (org-ai-on-project--reload))))
+    map))
+
+(define-minor-mode org-ai-on-project-mode
+  "Minor mode for org-ai-on-project."
+  :lighter " org-ai-on-project"
+  :keymap org-ai-on-project-mode-map
+  :group 'org-ai-on-project)
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+(defcustom org-ai-on-project-default-prompt
+  "In the following, I will show you a request and a list of file names together with their content. The files belong to the same project. I want you to answer the request using the file contents.
+
+Here is the request:
+I want you to <ENTER YOUR REQUEST HERE>
+
+Here are the files:"
+  "Default prompt for org-ai-on-project."
+  :type 'string
+  :group 'org-ai-on-project)
+
+(defun org-ai-on-project--run (state)
+  ""
+  (let ((buf (get-buffer-create "*org-ai-on-project-result*"))
+        (files (cl-loop for file in (org-ai-on-project--state-files state)
+                        when (org-ai-on-project--file-chosen file)
+                        collect file)))
+    (with-current-buffer buf
+      (erase-buffer)
+      (insert (org-ai-on-project--state-prompt state))
+      (insert "\n")
+      (cl-loop for file in files
+               do (let ((content (org-ai-on-project--get-file-content file))
+                        (file (org-ai-on-project--file-file file)))
+                    (insert file "\n")
+                    (insert "```\n")
+                    (insert content)
+                    (insert "```\n\n")))
+      (insert "Now answer the request!\n\n"))
+    (switch-to-buffer buf)
+
+    (let ((prompt (buffer-string)))
+      (org-ai-prompt prompt :output-buffer (current-buffer) :callback (lambda (response) (message "done"))))))
+
+;;;###autoload
+(defun org-ai-on-project (&optional base-dir)
+  "Start org-ai-on-project.
+This is a command that will allow you to run an org-ai prompt on
+multiple files. You can select the files using a glob expression
+and optionally select regions inside of the files.
+
+Those files will then be concatenated and passed to org-ai with
+your prompt."
+  (interactive)
+  (org-ai-on-project--render
+   (make-org-ai-on-project--state :files nil
+                                  :base-dir (or base-dir default-directory)
+                                  :pattern "**/*"
+                                  :prompt org-ai-on-project-default-prompt)))
+
+;;; org-ai-on-project.el ends here

--- a/org-ai-on-project.el
+++ b/org-ai-on-project.el
@@ -24,11 +24,11 @@
 
 (require 'cl-lib)
 (require 'widget)
+(require 'wid-edit)
+(require 'diff-mode)
+
+(require 'org-ai-openai)
 (require 'org-ai-useful)
-
-(eval-when-compile
-  (require 'wid-edit))
-
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; customizations
@@ -47,7 +47,7 @@ The files are shown in the format
 
 Here are the files:
 "
-  "Default prompt for `org-ai-on-project' in which to embed the users request in."
+  "Default prompt for `org-ai-on-project' in which to embed the users request."
   :type 'string
   :group 'org-ai-on-project)
 
@@ -130,7 +130,7 @@ patches."
 (defvar org-ai-on-project--result-buffer-name "*org-ai-on-project-result*"
   "Name of the on-project result buffer.")
 
-(defvar org-ai-on-project--current-request-in-progress nil "")
+(defvar org-ai-on-project--current-request-in-progress nil)
 
 (defvar org-ai-on-project--file-prefix ".orgai__"
   "Prefix used for files created by the responses.")
@@ -146,34 +146,13 @@ E.g. bar/foo.txt -> bar/.orgai__foo.txt."
    (concat "\\1" org-ai-on-project--file-prefix "\\2")
    file))
 
-(defun org-ai-on-project--find-files-with-projectile (project-dir regexp)
-  "Find files in BASE-DIR matching REGEXP.
-This requires BASE-DIR to be a projectile project."
-  (cl-loop with found-files = nil
-           with found-org-ai-files = (make-hash-table :test #'equal)
-           with org-ai-file-p
-
-           for file in (projectile-project-files project-dir)
-
-           do (setq org-ai-file-p (string-match-p org-ai-on-project--file-prefix file))
-
-           when org-ai-file-p
-           do (let ((orig-file (string-replace org-ai-on-project--file-prefix "" file)))
-                (puthash orig-file file found-org-ai-files))
-           when (string-match-p regexp file)
-
-           when (and (not org-ai-file-p)
-                     (string-match-p regexp file))
-           do (push (make-org-ai-on-project--file
-                     :file file
-                     :full-path (expand-file-name file project-dir))
-                    found-files)
-
-           finally return (cons
-                           (nreverse found-files)
-                           (unless (hash-table-empty-p found-org-ai-files) found-org-ai-files))))
+(declare-function projectile-project-root "projectile")
+(declare-function projectile-project-files "projectile")
 
 (defun org-ai-on-project--find-files (base-dir regexp)
+  "Find files in BASE-DIR matching REGEXP.
+This uses projectile if it is available. Otherwise it restorts to
+`directory-files-recursively'."
   (let (raw-files raw-org-ai-files)
 
     (if-let* ((project-dir (and (boundp 'projectile-mode)
@@ -220,6 +199,9 @@ This requires BASE-DIR to be a projectile project."
                              (unless (hash-table-empty-p found-org-ai-files) found-org-ai-files)))))
 
 (defun org-ai-on-project--do-search (state)
+  "Find files matching the search pattern in STATE.
+Find file modifications of previous prompts.
+Add all those to STATE."
   (let* ((base-dir (org-ai-on-project--state-base-dir state))
          (pattern (org-ai-on-project--state-file-search-pattern state))
          (search-result (org-ai-on-project--find-files base-dir pattern)))
@@ -239,7 +221,7 @@ This requires BASE-DIR to be a projectile project."
       (insert-file-contents full-path)
       (goto-char (point-max))
       ;; ensure newline at end
-      (unless (looking-back "\n")
+      (unless (looking-back "\n" 1)
         (insert "\n")
         ;; ensure the original file has it as well, otherwise we can get issues
         ;; with patching
@@ -253,7 +235,12 @@ This requires BASE-DIR to be a projectile project."
       (buffer-substring-no-properties start end))))
 
 (defmacro org-ai-on-on-project--do-only-with-selected-file-content (file &rest body)
-  ""
+  "Helper macro to temporarily replace the content of FILE.
+If file has a region set, put the content of that region into a
+the file and run BODY. After BODY is done, restore the file and
+move the potentially modified contents of file into that region.
+If FILE has no region set, just run BODY in the context of the
+file buffer."
   (declare (indent 1) (debug t))
   `(let* ((region (org-ai-on-project--file-region ,file))
           (full-path (org-ai-on-project--file-full-path ,file))
@@ -272,7 +259,9 @@ This requires BASE-DIR to be a projectile project."
                (basic-save-buffer)
                ,@body
                (with-current-buffer file-buffer
-                 (let ((new-content (buffer-string)))
+                 (let (start
+                       end
+                       (new-content (buffer-string)))
                    (with-current-buffer backup-buffer
                      (goto-char (car region))
                      (beginning-of-line)
@@ -304,6 +293,9 @@ code
 `START' and `END' are optional and can be used to limit the
 region.
 
+`EXPECT-DIFFS' is optional and if set to t, will expect that
+the model outputs a unified diff instead of verbatim code.
+
 Will return a hash table with the file names as keys and the
 code as values."
   (let ((content (buffer-substring-no-properties (or start (point-min))
@@ -311,7 +303,7 @@ code as values."
         (result (make-hash-table :test 'equal)))
     (with-temp-buffer
       (insert content)
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (cl-loop while (search-forward "```" nil t)
                ;; sanity check, is this a code block, not embedded?
                when (= (current-column) 3)
@@ -334,10 +326,10 @@ code as values."
                                         (insert " ")
                                         (forward-char -1))
                                       (forward-line 1))))
-                        (search-forward "```")
-                        (setq file-content (buffer-substring-no-properties
-                                            content-start
-                                            (line-beginning-position))))
+                      (search-forward "```")
+                      (setq file-content (buffer-substring-no-properties
+                                          content-start
+                                          (line-beginning-position))))
                     (puthash file-name file-content result)))
       result)))
 
@@ -369,7 +361,7 @@ code as values."
                 (display-buffer buffer-a)
                 (when (y-or-n-p "Apply diff? ")
                   (diff--iterate-hunks (point-max)
-                                       (lambda (&rest ignore) (diff-apply-hunk)))
+                                       (lambda (&rest _ignore) (diff-apply-hunk)))
                   (org-ai-on-project--remove-org-ai-file state file-name org-ai-file))
                 (kill-buffer buffer-b)
                 (with-current-buffer buffer-a (basic-save-buffer))
@@ -381,8 +373,14 @@ code as values."
             (progn
               (goto-char (car region))
               (set-mark (cadr region)))
-          (mark-whole-buffer)))
-      (with-current-buffer buffer-b (mark-whole-buffer))
+          (progn ;; mark-whole-buffer
+            (push-mark)
+            (push-mark (point-max) nil t)
+            (goto-char (point-min)))))
+      (with-current-buffer buffer-b (progn ;; mark-whole-buffer
+                                      (push-mark)
+                                      (push-mark (point-max) nil t)
+                                      (goto-char (point-min))))
       (when (org-ai--diff-and-patch-buffers buffer-a buffer-b file-name)
         (with-current-buffer buffer-a (basic-save-buffer))
         (org-ai-on-project--remove-org-ai-file state file-name org-ai-file)
@@ -400,11 +398,12 @@ code as values."
   :lighter " Select-Region"
   :keymap (let ((map (make-sparse-keymap)))
             (define-key map (kbd "C-c C-c") 'org-ai-on-project--confirm-selection)
-            (define-key map (kbd "C-c k") (lambda () (interactive) (org-ai-on-project--confirm-selection t)))
+            (define-key map (kbd (string-join (list "C-c" " k"))) (lambda () (interactive) (org-ai-on-project--confirm-selection t)))
             map))
 
 (defun org-ai-on-project--confirm-selection (&optional cancel)
-  "Confirm the selected region and stop `org-ai-on-project--select-region-mode`."
+  "Confirm the selected region and stop `org-ai-on-project--select-region-mode`.
+If CANCEL is non-nil, cancel the selection."
   (interactive)
   (when org-ai-on-project--select-region-mode
     (let ((region (when (and (not cancel) (region-active-p)) (list (region-beginning) (region-end))))
@@ -445,7 +444,8 @@ FILE is of type `org-ai-on-project--file`. It is not a string!"
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; "UI" for the on-project buffer
 
-(defmacro with-on-project-buffer (&rest body)
+(defmacro org-ai-on-project--with-on-project-buffer (&rest body)
+  "Ensure/setup `org-ai-on-project--buffer-name` and execute BODY."
   `(progn
      (kill-buffer (get-buffer-create org-ai-on-project--buffer-name))
      (switch-to-buffer (get-buffer-create org-ai-on-project--buffer-name))
@@ -459,12 +459,12 @@ FILE is of type `org-ai-on-project--file`. It is not a string!"
        (org-ai-on-project-mode 1))))
 
 (defun org-ai-on-project--render (state)
+  "Render STATE using widgets in `org-ai-on-project--buffer-name`."
   (let ((base-dir (org-ai-on-project--state-base-dir state))
-        (files (org-ai-on-project--state-files state))
         (has-modifications-p (org-ai-on-project--state-org-ai-files state))
         (pos (if-let ((buf (get-buffer org-ai-on-project--buffer-name))) (with-current-buffer buf (point)) 0)))
 
-    (with-on-project-buffer
+    (org-ai-on-project--with-on-project-buffer
      (setq org-ai-on-project--last-state state)
      (setq-local default-directory base-dir)
 
@@ -497,7 +497,7 @@ FILE is of type `org-ai-on-project--file`. It is not a string!"
 STATE is `org-ai-on-project--state'."
   (widget-create 'text
                  :format "%v"
-                 :notify (lambda (widget &rest ignore)
+                 :notify (lambda (widget &rest _ignore)
                            (setf (org-ai-on-project--state-prompt state) (widget-value widget)))
                  (or (org-ai-on-project--state-prompt state) "")))
 
@@ -507,7 +507,7 @@ STATE is `org-ai-on-project--state'."
   (let ((pattern (org-ai-on-project--state-file-search-pattern state)))
     (widget-create 'editable-field :size 40 :format "Files: %v " pattern)
     (widget-create 'push-button
-                   :notify (lambda (&rest ignore)
+                   :notify (lambda (&rest _ignore)
                              (widget-backward 1)
                              (let ((pos (point))
                                    (pattern (widget-value (widget-at (point))))
@@ -525,10 +525,7 @@ If we have modifications, offer diff/patch options.
 STATE is `org-ai-on-project--state'."
   (let* ((files (org-ai-on-project--state-files state))
          (has-modifications-p (org-ai-on-project--state-org-ai-files state))
-         (too-many-files-p (> (length files) org-ai-on-project-max-files))
-         (files-limited (if too-many-files-p
-                            (seq-take files org-ai-on-project-max-files)
-                          files)))
+         (too-many-files-p (> (length files) org-ai-on-project-max-files)))
     (if has-modifications-p
         (cl-loop for file in files
                  do (org-ai-on-project--render-file-with-modification state file))
@@ -543,7 +540,7 @@ STATE is `org-ai-on-project--state'."
   (widget-insert "\n")
 
   (widget-create 'push-button
-                 :notify (lambda (&rest ignore)
+                 :notify (lambda (&rest _ignore)
                            (cl-loop with files = (org-ai-on-project--state-files state)
                                     for file in files
                                     do (setf (org-ai-on-project--file-chosen file) t))
@@ -551,7 +548,7 @@ STATE is `org-ai-on-project--state'."
                  "Select all")
   (widget-insert " ")
   (widget-create 'push-button
-                 :notify (lambda (&rest ignore)
+                 :notify (lambda (&rest _ignore)
                            (cl-loop with files = (org-ai-on-project--state-files state)
                                     for file in files
                                     do (setf (org-ai-on-project--file-chosen file) nil))
@@ -559,11 +556,14 @@ STATE is `org-ai-on-project--state'."
                  "Select none"))
 
 
-(defun org-ai-on-project--render-file-without-modification (state file)
+(defun org-ai-on-project--render-file-without-modification (_state file)
+  "Render FILE without modification using _STATE.
+_STATE is `org-ai-on-project--state'.
+FILE is `org-ai-on-project--file'."
   (let ((file-name (org-ai-on-project--file-file file))
         (chosen (org-ai-on-project--file-chosen file)))
     (widget-create 'checkbox
-                   :notify (lambda (widget &rest ignore)
+                   :notify (lambda (&rest _ignore)
                              (setf (org-ai-on-project--file-chosen file) (not chosen)))
                    chosen)
     (widget-insert " ")
@@ -571,11 +571,11 @@ STATE is `org-ai-on-project--state'."
                    :button-prefix ""
                    :button-suffix ""
                    :button-face 'widget-field-face
-                   :notify (lambda (&rest ignore) (find-file file-name))
+                   :notify (lambda (&rest _ignore) (find-file file-name))
                    file-name)
     (widget-insert " ")
     (widget-create 'push-button
-                   :notify (lambda (&rest ignore)
+                   :notify (lambda (&rest _ignore)
                              (org-ai-on-project--select-region-in-file file))
                    (if-let ((region (org-ai-on-project--file-region file)))
                        (format "%s-%s" (car region) (cadr region))
@@ -587,7 +587,6 @@ STATE is `org-ai-on-project--state'."
 STATE is `org-ai-on-project--state'.
 FILE is `org-ai-on-project--file'."
   (let* ((file-name (org-ai-on-project--file-file file))
-         (region (org-ai-on-project--file-region file))
          (org-ai-files (org-ai-on-project--state-org-ai-files state))
          (org-ai-file (gethash file-name org-ai-files)))
 
@@ -595,13 +594,13 @@ FILE is `org-ai-on-project--file'."
                    :button-prefix ""
                    :button-suffix ""
                    :button-face 'widget-field-face
-                   :notify (lambda (&rest ignore) (find-file file-name))
+                   :notify (lambda (&rest _ignore) (find-file file-name))
                    file-name)
     (widget-insert " ")
 
     (when org-ai-file
       (widget-create 'push-button
-                     :notify (lambda (&rest ignore)
+                     :notify (lambda (&rest _ignore)
                                (find-file org-ai-file)
                                (when (org-ai-on-project--state-modify-with-diffs state)
                                  (diff-mode)))
@@ -609,12 +608,12 @@ FILE is `org-ai-on-project--file'."
       (widget-insert " ")
 
       (widget-create 'push-button
-                     :notify (lambda (&rest ignore) (org-ai-on-project--patch-file state file))
+                     :notify (lambda (&rest _ignore) (org-ai-on-project--patch-file state file))
                      "Patch")
       (widget-insert " ")
 
       (widget-create 'push-button
-                     :notify (lambda (&rest ignore)
+                     :notify (lambda (&rest _ignore)
                                (org-ai-on-project--remove-org-ai-file state file-name org-ai-file)
                                (org-ai-on-project--render state)
                                (beginning-of-line))
@@ -627,7 +626,7 @@ FILE is `org-ai-on-project--file'."
 STATE is `org-ai-on-project--state'."
   (widget-insert "Modify code: ")
   (widget-create 'checkbox
-                 :notify (lambda (widget &rest ignore)
+                 :notify (lambda (widget &rest _ignore)
                            (setf (org-ai-on-project--state-modify-code state)
                                  (widget-value widget)))
                  (org-ai-on-project--state-modify-code state))
@@ -635,7 +634,7 @@ STATE is `org-ai-on-project--state'."
 
   (widget-insert "Request diffs: ")
   (widget-create 'checkbox
-                 :notify (lambda (widget &rest ignore)
+                 :notify (lambda (&rest _ignore)
                            (setf (org-ai-on-project--state-modify-with-diffs state)
                                  org-ai-on-project-modify-with-diffs))
                  (org-ai-on-project--state-modify-with-diffs state))
@@ -643,7 +642,7 @@ STATE is `org-ai-on-project--state'."
   (widget-insert "\n\n")
 
   (widget-create 'push-button
-                 :notify (lambda (&rest ignore)
+                 :notify (lambda (&rest _ignore)
                            (org-ai-on-project--run state))
                  "Run"))
 
@@ -651,33 +650,33 @@ STATE is `org-ai-on-project--state'."
   "Render some controls.
 STATE is `org-ai-on-project--state'."
   (widget-create 'push-button
-                 :notify (lambda (&rest ignore)
+                 :notify (lambda (&rest _ignore)
                            (org-ai-on-project--remove-org-ai-files state)
                            (org-ai-on-project--run state))
                  "Run again")
   (widget-insert "\n\n")
   (widget-create 'push-button
-                 :notify (lambda (&rest ignore) (org-ai-on-project--run state))
+                 :notify (lambda (&rest _ignore) (org-ai-on-project--run state))
                  "Diff all")
   (widget-insert " ")
   (widget-create 'push-button
-                 :notify (lambda (&rest ignore) (org-ai-on-project--run state))
+                 :notify (lambda (&rest _ignore) (org-ai-on-project--run state))
                  "Patch all")
   (widget-insert "\n\n")
   (widget-create 'push-button
-                 :notify (lambda (&rest ignore)
+                 :notify (lambda (&rest _ignore)
                            (let ((org-ai-files (org-ai-on-project--state-org-ai-files state)))
                              (when (and org-ai-files (y-or-n-p "Discard changes?"))
                                (org-ai-on-project--remove-org-ai-files state)
                                (org-ai-on-project--render state)
-                               (beginning-of-buffer))))
+                               (goto-char (point-min)))))
                  "Reset"))
 
 (defun org-ai-on-project--render-quit (state)
   "Render a quit button.
 STATE is `org-ai-on-project--state'."
   (widget-create 'push-button
-                 :notify (lambda (&rest ignore)
+                 :notify (lambda (&rest _ignore)
                            (let ((org-ai-files (org-ai-on-project--state-org-ai-files state)))
                              (when (or (not org-ai-files) (y-or-n-p "Discard changes?"))
                                (org-ai-on-project--remove-org-ai-files state)
@@ -685,12 +684,14 @@ STATE is `org-ai-on-project--state'."
                  "Quit"))
 
 (defun org-ai-on-project--reload ()
+  "Reload the on-project buffer."
   (when (buffer-live-p (get-buffer org-ai-on-project--buffer-name))
     (with-current-buffer org-ai-on-project--buffer-name
       (org-ai-on-project--render org-ai-on-project--last-state))))
 
 (defun org-ai-on-project--self-insert-command (N)
-  "Helper for buffer commands."
+  "Helper for buffer commands.
+N is the number of times to repeat the command."
   (interactive "p")
   (if (eq 'editable-field (widget-type (widget-at (point))))
       (self-insert-command N)
@@ -784,7 +785,7 @@ requested) or we:
                               (org-ai-chat-request
                                :messages (org-ai--collect-chat-messages prompt)
                                :model org-ai-default-chat-model
-                               :callback (lambda (content role usage)
+                               :callback (lambda (content _role _usage)
                                            (with-current-buffer buf
                                              (save-excursion (insert content))
                                              (when-let ((request (org-ai-on-project--request-cleanup)))
@@ -798,7 +799,8 @@ requested) or we:
       (setq org-ai-on-project--current-request-in-progress request))))
 
 (defun org-ai-on-project--request-cleanup ()
-  ""
+  "Cleans up the current `org-ai-on-project--current-request-in-progress'.
+This will kill the url response buffer."
   (when-let (current org-ai-on-project--current-request-in-progress)
     ;; (display-buffer (org-ai-on-project--request-in-progress-url-response-buffer current))
     (unless org-ai-on-project-use-stream
@@ -807,7 +809,7 @@ requested) or we:
     current))
 
 (defun org-ai-on-project--run-done (request)
-  ""
+  "Takes the current REQUEST and does the post-processing."
   (let ((pos (org-ai-on-project--request-in-progress-start-pos request))
         (state (org-ai-on-project--request-in-progress-state request)))
     (goto-char pos)
@@ -832,17 +834,20 @@ requested) or we:
         (search-forward "Patch" nil t)))))
 
 (defun org-ai-on-project--remove-org-ai-files (state)
-  "Remove all the .orgai__* files created by org-ai-on-project."
+  "Remove all the .orgai__* files created by org-ai-on-project.
+STATE is the current state."
   (when-let (org-ai-files (org-ai-on-project--state-org-ai-files state))
-    (cl-loop for key being the hash-keys of org-ai-files
-             using (hash-values value)
+    (cl-loop for value being the hash-values of org-ai-files
              do (when (file-exists-p value)
                   (delete-file value)))
     (setf (org-ai-on-project--state-org-ai-files state) nil)
     t))
 
 (defun org-ai-on-project--remove-org-ai-file (state orig-file org-ai-file)
-  "Remove all the .orgai__* files created by org-ai-on-project."
+  "Remove all the .orgai__* files created by org-ai-on-project.
+ORIG-FILE is the original file that was modified.
+ORG-AI-FILE is the .org-ai__ file that was created.
+STATE is the current state."
   (when-let (org-ai-files (org-ai-on-project--state-org-ai-files state))
     (remhash orig-file org-ai-files)
     (when (file-exists-p org-ai-file)
@@ -854,7 +859,7 @@ requested) or we:
 
 ;;;###autoload
 (defun org-ai-on-project (&optional base-dir)
-  "Start org-ai-on-project.
+  "Start org-ai-on-project inside BASE-DIR.
 This is a command that will allow you to run an org-ai prompt on
 multiple files. You can select the files using a regexp expression
 and optionally select regions inside of the files.
@@ -879,5 +884,8 @@ your prompt."
                                                             ""))))
         (org-ai-on-project--do-search state)
         (org-ai-on-project--render state)))))
+
+
+(provide 'org-ai-on-project)
 
 ;;; org-ai-on-project.el ends here

--- a/org-ai-on-project.el
+++ b/org-ai-on-project.el
@@ -57,7 +57,7 @@
   url-response-buffer
   spinner)
 
-(defvar-local org-ai-on-project--current-state nil
+(defvar-local org-ai-on-project--last-state nil
   "Current state of the on-project buffer.")
 
 (defvar org-ai-on-project--buffer-name "*org-ai-on-project*"
@@ -76,9 +76,7 @@
 (defun org-ai-on-project--reload ()
   (when (buffer-live-p (get-buffer org-ai-on-project--buffer-name))
     (with-current-buffer org-ai-on-project--buffer-name
-      (let ((pos (point)))
-        (org-ai-on-project--render org-ai-on-project--current-state)
-        (goto-char pos)))))
+      (org-ai-on-project--render org-ai-on-project--last-state))))
 
 (defun org-ai-on-project--find-files (base-dir patterns)
   (let* ((default-directory base-dir)
@@ -139,19 +137,19 @@
   "Read the content of FILE and return it as a string."
   (declare (indent 1))
   (let* ((full-path (org-ai-on-project--file-full-path file))
-          (region (org-ai-on-project--file-region file))
-          (region-start (car region))
-          (region-end (cadr region))
-          start end)
-     (with-temp-buffer
-       (insert-file-contents full-path)
-       (goto-char (or region-start (point-min)))
-       (beginning-of-line)
-       (setq start (point))
-       (goto-char (or region-start (point-max)))
-       (end-of-line)
-       (setq end (point))
-       (buffer-substring-no-properties start end))))
+         (region (org-ai-on-project--file-region file))
+         (region-start (car region))
+         (region-end (cadr region))
+         start end)
+    (with-temp-buffer
+      (insert-file-contents full-path)
+      (goto-char (or region-start (point-min)))
+      (beginning-of-line)
+      (setq start (point))
+      (goto-char (or region-start (point-max)))
+      (end-of-line)
+      (setq end (point))
+      (buffer-substring-no-properties start end))))
 
 (defun org-ai-on-project--extract-files-and-code-blocks (&optional start end)
   "Expects that the current buffer shows files and code.
@@ -170,29 +168,29 @@ Will return a hash table with the file names as keys and the
 code as values."
   (let ((content (buffer-substring-no-properties (or start (point-min))
                                                  (or end (point-max))))
-                 (result (make-hash-table :test 'equal)))
-        (with-temp-buffer
-          (insert content)
-          (beginning-of-buffer)
-          (cl-loop while (search-forward "```" nil t)
-                   ;; sanity check, is this a code block, not embedded?
-                   when (= (current-column) 3)
-                   do (let (file-name file-content)
-                        ;; we are at the end of the code block start
-                        ;; get the file name
-                        (beginning-of-line)
-                        (forward-line -1)
-                        (setq file-name (buffer-substring-no-properties
-                                         (line-beginning-position)
-                                         (line-end-position)))
-                        (forward-line 2)
-                        (let ((content-start (point)))
-                          (search-forward "```")
-                          (setq file-content (buffer-substring-no-properties
-                                              content-start
-                                              (line-beginning-position))))
-                        (puthash file-name file-content result)))
-          result)))
+        (result (make-hash-table :test 'equal)))
+    (with-temp-buffer
+      (insert content)
+      (beginning-of-buffer)
+      (cl-loop while (search-forward "```" nil t)
+               ;; sanity check, is this a code block, not embedded?
+               when (= (current-column) 3)
+               do (let (file-name file-content)
+                    ;; we are at the end of the code block start
+                    ;; get the file name
+                    (beginning-of-line)
+                    (forward-line -1)
+                    (setq file-name (buffer-substring-no-properties
+                                     (line-beginning-position)
+                                     (line-end-position)))
+                    (forward-line 2)
+                    (let ((content-start (point)))
+                      (search-forward "```")
+                      (setq file-content (buffer-substring-no-properties
+                                          content-start
+                                          (line-beginning-position))))
+                    (puthash file-name file-content result)))
+      result)))
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; helper mode and functions for selecting regions in files
@@ -223,8 +221,7 @@ code as values."
         (kill-this-buffer))
       (when file (setf (org-ai-on-project--file-region file) region))
       (org-ai-on-project--reload)
-      (switch-to-buffer org-ai-on-project--buffer-name)
-      (message "...%s" (current-buffer)))))
+      (switch-to-buffer org-ai-on-project--buffer-name))))
 
 (defun org-ai-on-project--select-region-in-file (file)
   "Open FILE and start `org-ai-on-project--select-region-mode` to select a region.
@@ -233,12 +230,12 @@ FILE is of type `org-ai-on-project--file`. It is not a string!"
 
   (let* ((file-path (org-ai-on-project--file-full-path file))
          (buf (if-let ((buf (find-buffer-visiting file-path)))
-                 (with-current-buffer buf
-                   (setq org-ai-on-project--select-region-file-already-open t)
-                   buf)
-               (find-file-literally file-path)
-               (setq org-ai-on-project--select-region-file-already-open nil)
-               (current-buffer))))
+                  (with-current-buffer buf
+                    (setq org-ai-on-project--select-region-file-already-open t)
+                    buf)
+                (find-file-literally file-path)
+                (setq org-ai-on-project--select-region-file-already-open nil)
+                (current-buffer))))
     (with-current-buffer buf
       (setq org-ai-on-project--select-region-file file)
       (org-ai-on-project--select-region-mode 1)
@@ -254,157 +251,179 @@ FILE is of type `org-ai-on-project--file`. It is not a string!"
      (switch-to-buffer (get-buffer-create org-ai-on-project--buffer-name))
      (kill-all-local-variables)
      (with-current-buffer org-ai-on-project--buffer-name
-       (toggle-truncate-lines -1)
+       (setq truncate-lines nil)
+       (setq word-wrap t)
        ,@body
        (use-local-map widget-keymap)
        (widget-setup)
-       (org-ai-on-project-mode 1)
-       (beginning-of-buffer))))
+       (org-ai-on-project-mode 1))))
 
 (defun org-ai-on-project--render (state)
   (let ((base-dir (org-ai-on-project--state-base-dir state))
         (files (org-ai-on-project--state-files state))
-        (org-ai-files (org-ai-on-project--state-org-ai-files state))
-        (pattern (org-ai-on-project--state-file-search-pattern state))
-        (prompt (org-ai-on-project--state-prompt state)))
+        (has-modifications-p (org-ai-on-project--state-org-ai-files state))
+        (pos (if-let ((buf (get-buffer org-ai-on-project--buffer-name))) (with-current-buffer buf (point)) 0)))
 
     (with-on-project-buffer
-     (setq org-ai-on-project--current-state state)
+     (setq org-ai-on-project--last-state state)
      (setq-local default-directory base-dir)
 
      (widget-insert "On project: " base-dir "\n\n")
-
-     (widget-create 'text
-                    :format "Prompt: %v"
-                    :notify (lambda (widget &rest ignore)
-                              (let ((new-prompt (widget-value widget)))
-                                (setf (org-ai-on-project--state-prompt state) new-prompt)
-                                (setq prompt new-prompt)))
-                    (or (org-ai-on-project--state-prompt state) ""))
-
+     (org-ai-on-project--render-prompt state)
      (widget-insert "\n\n")
 
-
-     (if org-ai-files
+     ;; List files. If we have modifications, offer diff/patch options
+     (if has-modifications-p
          (progn
            (widget-insert "Files:\n\n")
            (cl-loop for file in files
-                    do (let* ((file-name (org-ai-on-project--file-file file))
-                              (org-ai-file (gethash file-name org-ai-files)))
-                         (widget-insert file-name " ")
-                         (when org-ai-file
-                           (widget-create 'push-button
-                                          :notify (lambda (&rest ignore)
-                                                    (message "a: %s b: %s" file-name org-ai-file)
-                                                    (let ((buffer-a (find-file-noselect file-name))
-                                                          (buffer-b (find-file-noselect org-ai-file)))
-                                                      (with-current-buffer buffer-a (mark-whole-buffer))
-                                                      (with-current-buffer buffer-b (mark-whole-buffer))
-                                                      (when (org-ai--diff-and-patch-buffers buffer-a buffer-b)
-                                                        (with-current-buffer buffer-a (save-buffer))
-                                                        (org-ai-on-project--remove-org-ai-file state file-name org-ai-file)
-                                                        (org-ai-on-project--render state))))
-                                          "Diff & Patch")
-
-                           (widget-insert " ")
-
-                           (widget-create 'push-button
-                                          :notify (lambda (&rest ignore)
-                                                    (org-ai-on-project--remove-org-ai-file state file-name org-ai-file)
-                                                    (org-ai-on-project--render state))
-                                          "Reset"))
-                         (widget-insert "\n"))))
+                    do (org-ai-on-project--render-file-with-modification state file)))
        (progn
-         (widget-create 'editable-field
-		        :size 40
-		        :format "Files: %v "    ; Text after the field!
-		        pattern)
-
-         (widget-create 'push-button
-                        :notify (lambda (&rest ignore)
-                                  (widget-backward 1)
-                                  (let ((pos (point))
-                                         (pattern (widget-value (widget-at (point)))))
-                                    (setf (org-ai-on-project--state-file-search-pattern state) pattern)
-                                    (org-ai-on-project--do-search state)
-                                    (org-ai-on-project--render state)
-                                    (goto-char pos)
-                                    (when org-ai-files (message "Found existing set of .orgai__* files!"))))
-                        "Search")
-         (widget-insert "\n\n")
-
+         (org-ai-on-project--render-search-input state)
          (cl-loop for file in files
-                  do (progn
-                       (widget-create 'checkbox
-                                      :notify (lambda (widget &rest ignore)
-                                                (setf (org-ai-on-project--file-chosen file) (widget-value widget)))
-                                      (org-ai-on-project--file-chosen file))
-                       (widget-insert " " (org-ai-on-project--file-file file) " ")
-                       (widget-create 'push-button
-                                      :notify (lambda (&rest ignore)
-                                                (org-ai-on-project--select-region-in-file file))
-                                      (if-let ((region (org-ai-on-project--file-region file)))
-                                          (format "%s-%s" (car region) (cadr region))
-                                        "entire file"))
-                       (widget-insert "\n")))
-
-         (widget-insert "\n\n")
-
-         (widget-insert "Modify code: ")
-         (widget-create 'checkbox
-                        :notify (lambda (widget &rest ignore)
-                                  (setf (org-ai-on-project--state-modify-code state)
-                                        (widget-value widget)))
-                        (org-ai-on-project--state-modify-code state))))
+                  do (org-ai-on-project--render-file-without-modification state file))))
 
      (widget-insert "\n\n")
 
-     (if org-ai-files
-         (progn
-           (widget-create 'push-button
-                          :notify (lambda (&rest ignore)
-                                    (org-ai-on-project--remove-org-ai-files state)
-                                    (org-ai-on-project--run state))
-                          "Run again")
-
-           (widget-insert "\n\n")
-
-           (widget-create 'push-button
-                          :notify (lambda (&rest ignore)
-                                    (org-ai-on-project--run state))
-                          "Diff all")
-
-           (widget-insert " ")
-
-           (widget-create 'push-button
-                          :notify (lambda (&rest ignore)
-                                    (org-ai-on-project--run state))
-                          "Patch all")
-
-           (widget-insert "\n\n")
-
-           (widget-create 'push-button
-                          :notify (lambda (&rest ignore)
-                                    (when (and org-ai-files (y-or-n-p "Discard changes?"))
-                                      (org-ai-on-project--remove-org-ai-files state)
-                                      (org-ai-on-project--render state)))
-                          "Reset"))
-
-       (widget-create 'push-button
-                      :notify (lambda (&rest ignore)
-                                (org-ai-on-project--run state))
-                      "Run"))
+     ;; render controls
+     (if has-modifications-p
+         (org-ai-on-project--render-with-modification-controls state)
+       (org-ai-on-project--render-without-modification-controls state))
 
      (widget-insert " ")
 
-     (widget-create 'push-button
-                    :notify (lambda (&rest ignore)
-                              (when (or (not org-ai-files) (y-or-n-p "Discard changes?"))
-                                (org-ai-on-project--remove-org-ai-files state)
-                                (kill-buffer)))
-                    "Quit")
+     (org-ai-on-project--render-quit state)
 
-     )))
+     (goto-char pos))))
+
+(defun org-ai-on-project--render-prompt (state)
+  "Render the input prompt.
+STATE is `org-ai-on-project--state'."
+  (widget-create 'text
+                 :format "Prompt: %v"
+                 :notify (lambda (widget &rest ignore)
+                           (setf (org-ai-on-project--state-prompt state) (widget-value widget)))
+                 (or (org-ai-on-project--state-prompt state) "")))
+
+(defun org-ai-on-project--render-search-input (state)
+  "Render the search input widget.
+STATE is `org-ai-on-project--state'."
+  (let ((pattern (org-ai-on-project--state-file-search-pattern state)))
+    (widget-create 'editable-field :size 40 :format "Files: %v " pattern)
+    (widget-create 'push-button
+                   :notify (lambda (&rest ignore)
+                             (widget-backward 1)
+                             (let ((pos (point))
+                                   (pattern (widget-value (widget-at (point))))
+                                   (org-ai-files (org-ai-on-project--state-org-ai-files state)))
+                               (setf (org-ai-on-project--state-file-search-pattern state) pattern)
+                               (org-ai-on-project--do-search state)
+                               (org-ai-on-project--render state)
+                               (goto-char pos)
+                               (when org-ai-files (message "Found existing set of .orgai__* files!"))))
+                   "Search")
+    (widget-insert "\n\n")))
+
+(defun org-ai-on-project--render-file-without-modification (state file)
+  (let ((file-name (org-ai-on-project--file-file file))
+        (chosen (org-ai-on-project--file-chosen file)))
+    (widget-create 'checkbox
+                   :notify (lambda (widget &rest ignore)
+                             (setf (org-ai-on-project--file-chosen file) (not chosen)))
+                   chosen)
+    (widget-insert " " file-name " ")
+    (widget-create 'push-button
+                   :notify (lambda (&rest ignore)
+                             (org-ai-on-project--select-region-in-file file))
+                   (if-let ((region (org-ai-on-project--file-region file)))
+                       (format "%s-%s" (car region) (cadr region))
+                     "entire file"))
+    (widget-insert "\n")))
+
+(defun org-ai-on-project--render-file-with-modification (state file)
+  "Render FILE with available modifications (org-ai-file).
+STATE is `org-ai-on-project--state'.
+FILE is `org-ai-on-project--file'."
+  (let* ((file-name (org-ai-on-project--file-file file))
+         (org-ai-files (org-ai-on-project--state-org-ai-files state))
+         (org-ai-file (gethash file-name org-ai-files)))
+    (widget-insert file-name " ")
+    (when org-ai-file
+        (widget-create 'push-button
+                       :notify (lambda (&rest ignore)
+                                 (let ((buffer-a (find-file-noselect file-name))
+                                       (buffer-b (find-file-noselect org-ai-file)))
+                                   (with-current-buffer buffer-a (mark-whole-buffer))
+                                   (with-current-buffer buffer-b (mark-whole-buffer))
+                                   (when (org-ai--diff-and-patch-buffers buffer-a buffer-b)
+                                     (with-current-buffer buffer-a (save-buffer))
+                                     (org-ai-on-project--remove-org-ai-file state file-name org-ai-file)
+                                     (org-ai-on-project--render state))))
+                       "Diff & Patch")
+
+      (widget-insert " ")
+      (widget-create 'push-button
+                     :notify (lambda (&rest ignore)
+                               (org-ai-on-project--remove-org-ai-file state file-name org-ai-file)
+                               (org-ai-on-project--render state)
+                               (beginning-of-line))
+                     "Reset"))
+    (widget-insert "\n")))
+
+(defun org-ai-on-project--render-without-modification-controls (state)
+  "Render some controls.
+STATE is `org-ai-on-project--state'."
+  (widget-insert "Modify code: ")
+  (widget-create 'checkbox
+                 :notify (lambda (widget &rest ignore)
+                           (setf (org-ai-on-project--state-modify-code state)
+                                 (widget-value widget)))
+                 (org-ai-on-project--state-modify-code state))
+
+  (widget-insert "\n\n")
+
+  (widget-create 'push-button
+                 :notify (lambda (&rest ignore)
+                           (org-ai-on-project--run state))
+                 "Run"))
+
+(defun org-ai-on-project--render-with-modification-controls (state)
+  "Render some controls.
+STATE is `org-ai-on-project--state'."
+  (widget-create 'push-button
+                 :notify (lambda (&rest ignore)
+                           (org-ai-on-project--remove-org-ai-files state)
+                           (org-ai-on-project--run state))
+                 "Run again")
+  (widget-insert "\n\n")
+  (widget-create 'push-button
+                 :notify (lambda (&rest ignore) (org-ai-on-project--run state))
+                 "Diff all")
+  (widget-insert " ")
+  (widget-create 'push-button
+                 :notify (lambda (&rest ignore) (org-ai-on-project--run state))
+                 "Patch all")
+  (widget-insert "\n\n")
+  (widget-create 'push-button
+                 :notify (lambda (&rest ignore)
+                           (let ((org-ai-files (org-ai-on-project--state-org-ai-files state)))
+                             (when (and org-ai-files (y-or-n-p "Discard changes?"))
+                               (org-ai-on-project--remove-org-ai-files state)
+                               (org-ai-on-project--render state)
+                               (beginning-of-buffer))))
+                 "Reset"))
+
+(defun org-ai-on-project--render-quit (state)
+  "Render a quit button.
+STATE is `org-ai-on-project--state'."
+  (widget-create 'push-button
+                 :notify (lambda (&rest ignore)
+                           (let ((org-ai-files (org-ai-on-project--state-org-ai-files state)))
+                             (when (or (not org-ai-files) (y-or-n-p "Discard changes?"))
+                               (org-ai-on-project--remove-org-ai-files state)
+                               (kill-buffer))))
+                 "Quit"))
+
 
 (defun org-ai-on-project--self-insert-command (N)
   "Helper for buffer commands."
@@ -439,7 +458,7 @@ FILE is of type `org-ai-on-project--file`. It is not a string!"
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 (defcustom org-ai-on-project-default-prompt
-  "In the following, I will show you a request and a list of file names together with their content. The files belong to the same project. I want you to answer the request using the file contents.
+  "I will show you a request and a list of file names together with their content. The files belong to the same project. I want you to answer the request using the file contents.
 
 Here is the request:
 %s
@@ -513,6 +532,7 @@ requested) or we:
 
     ;; now run the AI model on it
     (let* ((prompt (with-current-buffer buf (buffer-string)))
+           (start-pos (with-current-buffer buf (point)))
 
            (response-buffer (if org-ai-on-project-use-stream
                                 (org-ai-prompt prompt
@@ -532,7 +552,7 @@ requested) or we:
 
            (request (make-org-ai-on-project--request-in-progress
                      :state state
-                     :start-pos (point)
+                     :start-pos start-pos
                      :spinner (spinner-start 'progress-bar)
                      :url-response-buffer response-buffer)))
 
@@ -556,7 +576,7 @@ requested) or we:
 
     ;; extract & write the modified files if the user requested that
     (when (org-ai-on-project--state-modify-code state)
-      (let ((modified (org-ai-on-project--extract-files-and-code-blocks))
+      (let ((modified (org-ai-on-project--extract-files-and-code-blocks pos (point-max)))
             (original-and-modified-files (make-hash-table :test 'equal)))
         (cl-loop for key being the hash-keys of modified
                  using (hash-values value)
@@ -594,43 +614,6 @@ requested) or we:
     t))
 
 
-
-(comment
-  org-ai-on-project--current-request-in-progress
-
-  ;; (replace-regexp-in-string "\\(.*/\\)?\\(.*\\)" (concat "\\1" org-ai-on-project--file-prefix "\\2") "foo/bar/baz.txt")
-
-  (with-current-buffer org-ai-on-project--result-buffer-name
-    (let ((pos (org-ai-on-project--request-in-progress-start-pos org-ai-on-project--current-request-in-progress)))
-      (goto-char pos)
-      (let ((modified (org-ai-on-project--extract-files-and-code-blocks))
-            (original-and-modified-files (make-hash-table :test 'equal)))
-        (cl-loop for key being the hash-keys of modified
-                 using (hash-values value)
-                 ;; for each file, create a __org-ai__ file that contains the modified content
-                 do (let ((modified-file (replace-regexp-in-string
-                                          "\\(.*/\\)?\\(.*\\)"
-                                          (concat "\\1" org-ai-on-project--file-prefix "\\2")
-                                          key)))
-                      (puthash key modified-file original-and-modified-files)
-                      (with-temp-file modified-file
-                        (insert value))))
-        (setf (org-ai-on-project--state-org-ai-files state) original-and-modified-files)
-        (bury-buffer)
-        (switch-to-buffer org-ai-on-project--buffer-name)
-        (org-ai-on-project--render state))))
-
-
-  (hash-table-keys xxx)
-  (gethash "test.js" xxx)
-
-  (ediff-merge-files "test.js" "__org-ai__test.js")
-  (setq file "foo/bar/baz.org")
-  (setq file "baz.org"))
-
-
-
-
 ;;;###autoload
 (defun org-ai-on-project (&optional base-dir)
   "Start org-ai-on-project.
@@ -642,13 +625,16 @@ Those files will then be concatenated and passed to org-ai with
 your prompt."
   (interactive)
   (if-let* ((buf (get-buffer org-ai-on-project--buffer-name))
-            (state (with-current-buffer buf org-ai-on-project--current-state)))
+            (state (with-current-buffer buf org-ai-on-project--last-state)))
       (progn
         (switch-to-buffer buf)
         (org-ai-on-project--render state))
     (let ((state (make-org-ai-on-project--state :base-dir (or base-dir default-directory)
+                                                :modify-code t
                                                 :file-search-pattern "**/*"
-                                                :prompt "")))
+                                                :prompt (if org-ai-on-project--last-state
+                                                            (org-ai-on-project--state-prompt org-ai-on-project--last-state)
+                                                          ""))))
       (org-ai-on-project--do-search state)
       (org-ai-on-project--render state))))
 

--- a/org-ai-on-project.el
+++ b/org-ai-on-project.el
@@ -655,14 +655,17 @@ STATE is `org-ai-on-project--state'."
                            (org-ai-on-project--run state))
                  "Run again")
   (widget-insert "\n\n")
-  (widget-create 'push-button
-                 :notify (lambda (&rest _ignore) (org-ai-on-project--run state))
-                 "Diff all")
-  (widget-insert " ")
-  (widget-create 'push-button
-                 :notify (lambda (&rest _ignore) (org-ai-on-project--run state))
-                 "Patch all")
-  (widget-insert "\n\n")
+
+  ;; not yet implemented
+  ;; (widget-create 'push-button
+  ;;                :notify (lambda (&rest _ignore) (org-ai-on-project--run state))
+  ;;                "Diff all")
+  ;; (widget-insert " ")
+  ;; (widget-create 'push-button
+  ;;                :notify (lambda (&rest _ignore) (org-ai-on-project--run state))
+  ;;                "Patch all")
+  ;; (widget-insert "\n\n")
+
   (widget-create 'push-button
                  :notify (lambda (&rest _ignore)
                            (let ((org-ai-files (org-ai-on-project--state-org-ai-files state)))

--- a/org-ai-on-project.el
+++ b/org-ai-on-project.el
@@ -24,7 +24,6 @@
 
 (require 'cl-lib)
 (require 'widget)
-(require 'spinner)
 (require 'org-ai-useful)
 
 (eval-when-compile
@@ -120,8 +119,7 @@ patches."
   "State of the request in progress."
   state
   start-pos
-  url-response-buffer
-  spinner)
+  url-response-buffer)
 
 (defvar-local org-ai-on-project--last-state nil
   "Current state of the on-project buffer.")
@@ -795,7 +793,6 @@ requested) or we:
            (request (make-org-ai-on-project--request-in-progress
                      :state state
                      :start-pos start-pos
-                     :spinner (spinner-start 'progress-bar)
                      :url-response-buffer response-buffer)))
 
       (setq org-ai-on-project--current-request-in-progress request))))
@@ -803,7 +800,6 @@ requested) or we:
 (defun org-ai-on-project--request-cleanup ()
   ""
   (when-let (current org-ai-on-project--current-request-in-progress)
-    (spinner-stop)
     ;; (display-buffer (org-ai-on-project--request-in-progress-url-response-buffer current))
     (unless org-ai-on-project-use-stream
       (kill-buffer (org-ai-on-project--request-in-progress-url-response-buffer current)))

--- a/org-ai-on-project.el
+++ b/org-ai-on-project.el
@@ -283,7 +283,7 @@ FILE is of type `org-ai-on-project--file`. It is not a string!"
          (cl-loop for file in files
                   do (org-ai-on-project--render-file-without-modification state file))))
 
-     (widget-insert "\n\n")
+     (widget-insert "\n")
 
      ;; render controls
      (if has-modifications-p
@@ -373,6 +373,23 @@ FILE is `org-ai-on-project--file'."
 (defun org-ai-on-project--render-without-modification-controls (state)
   "Render some controls.
 STATE is `org-ai-on-project--state'."
+  (widget-create 'push-button
+                 :notify (lambda (&rest ignore)
+                           (cl-loop with files = (org-ai-on-project--state-files state)
+                                    for file in files
+                                    do (setf (org-ai-on-project--file-chosen file) t))
+                           (org-ai-on-project--render state))
+                 "Select all")
+  (widget-insert " ")
+  (widget-create 'push-button
+                 :notify (lambda (&rest ignore)
+                           (cl-loop with files = (org-ai-on-project--state-files state)
+                                    for file in files
+                                    do (setf (org-ai-on-project--file-chosen file) nil))
+                           (org-ai-on-project--render state))
+                 "Select none")
+  (widget-insert "\n\n")
+
   (widget-insert "Modify code: ")
   (widget-create 'checkbox
                  :notify (lambda (widget &rest ignore)

--- a/org-ai-on-project.el
+++ b/org-ai-on-project.el
@@ -24,6 +24,7 @@
 
 (require 'cl-lib)
 (require 'widget)
+(require 'spinner)
 (require 'org-ai-useful)
 
 (eval-when-compile
@@ -48,12 +49,29 @@
   region
   chosen)
 
+(cl-defstruct org-ai-on-project--request-in-progress
+  "State of the request in progress."
+  state
+  start-pos
+  url-response-buffer
+  spinner)
+
 (defvar-local org-ai-on-project--current-state nil
   "Current state of the on-project buffer.")
 
 (defvar org-ai-on-project--buffer-name "*org-ai-on-project*"
   "Name of the on-project buffer.")
 
+(defvar org-ai-on-project--current-request-in-progress nil "")
+
+(defun my-toggle-spinner ()
+  (interactive)
+  (if my-spinner
+      (progn
+        (spinner-stop my-spinner)
+        (setq my-spinner nil))
+    (setq my-spinner (spinner-create 'progress-bar t))
+    (spinner-start my-spinner)))
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; helpers
@@ -67,8 +85,11 @@
 (defun org-ai-on-project--find-files (base-dir patterns)
   (let* ((default-directory base-dir)
          (patterns (string-split patterns " " t))
-         (known-project-files (and (fboundp #'projectile-current-project-files)
-                                   (projectile-current-project-files))))
+         (known-project-files (or
+                               (and (boundp 'projectile-mode)
+                                    projectile-mode
+                                    (fboundp #'projectile-current-project-files)
+                                    (projectile-current-project-files)))))
 
     ;; This is quite a hack here:
     ;; If we have a pattern like "**/*js", it will only search in subdirectories,
@@ -87,6 +108,7 @@
              for pattern in patterns
              do (cl-loop for file in (file-expand-wildcards pattern)
                          when (and (file-regular-p file)
+                                   (not (string-match-p "__org-ai__" file))
                                    (or (not known-project-files)
                                        (member file known-project-files)))
                          do (push (make-org-ai-on-project--file
@@ -114,6 +136,46 @@
        (setq end (point))
        (buffer-substring-no-properties start end))))
 
+(defun org-ai-on-project--extract-files-and-code-blocks (&optional start end)
+  "Expects that the current buffer shows files and code.
+This should be in the form:
+
+file-name
+```
+code
+```
+...
+
+`START' and `END' are optional and can be used to limit the
+region.
+
+Will return a hash table with the file names as keys and the
+code as values."
+  (let ((content (buffer-substring-no-properties (or start (point-min))
+                                                 (or end (point-max))))
+                 (result (make-hash-table :test 'equal)))
+        (with-temp-buffer
+          (insert content)
+          (beginning-of-buffer)
+          (cl-loop while (search-forward "```" nil t)
+                   ;; sanity check, is this a code block, not embedded?
+                   when (= (current-column) 3)
+                   do (let (file-name file-content)
+                        ;; we are at the end of the code block start
+                        ;; get the file name
+                        (beginning-of-line)
+                        (forward-line -1)
+                        (setq file-name (buffer-substring-no-properties
+                                         (line-beginning-position)
+                                         (line-end-position)))
+                        (forward-line 2)
+                        (let ((content-start (point)))
+                          (search-forward "```")
+                          (setq file-content (buffer-substring-no-properties
+                                              content-start
+                                              (line-beginning-position))))
+                        (puthash file-name file-content result)))
+          result)))
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; helper mode and functions for selecting regions in files
@@ -175,6 +237,7 @@ FILE is of type `org-ai-on-project--file`. It is not a string!"
      (switch-to-buffer (get-buffer-create org-ai-on-project--buffer-name))
      (kill-all-local-variables)
      (with-current-buffer org-ai-on-project--buffer-name
+       (toggle-truncate-lines -1)
        ,@body
        (use-local-map widget-keymap)
        (widget-setup)
@@ -302,13 +365,32 @@ Here are the files:"
   :type 'string
   :group 'org-ai-on-project)
 
+(defcustom org-ai-on-project-default-modify-prompt
+  "Now modify the code according to the request. Show it in the same format, file name followed by content. Leave out any files that you did not modify. You can add new files or split existing ones if necessary. Do not at any explanation whatsoever."
+  "Default prompt for org-ai-on-project."
+  :type 'string
+  :group 'org-ai-on-project)
+
+(defcustom org-ai-on-project-default-request-prompt
+  "Now answer the request using the file contents."
+  "Default prompt for org-ai-on-project."
+  :type 'string
+  :group 'org-ai-on-project)
+
+(defcustom org-ai-on-project-use-stream t
+  "If non-nil, use streaming to get the result.")
+
 (defun org-ai-on-project--run (state)
   ""
   (let ((buf (get-buffer-create "*org-ai-on-project-result*"))
+        (final-instruction (if (org-ai-on-project--state-modify-code state)
+                               org-ai-on-project-default-modify-prompt
+                             org-ai-on-project-default-request-prompt))
         (files (cl-loop for file in (org-ai-on-project--state-files state)
                         when (org-ai-on-project--file-chosen file)
                         collect file)))
     (with-current-buffer buf
+      (toggle-truncate-lines -1)
       (erase-buffer)
       (insert (org-ai-on-project--state-prompt state))
       (insert "\n")
@@ -319,11 +401,73 @@ Here are the files:"
                     (insert "```\n")
                     (insert content)
                     (insert "```\n\n")))
-      (insert "Now answer the request!\n\n"))
+      (insert final-instruction "\n\n")
     (switch-to-buffer buf)
+    (recenter-top-bottom 1)
 
-    (let ((prompt (buffer-string)))
-      (org-ai-prompt prompt :output-buffer (current-buffer) :callback (lambda (response) (message "done"))))))
+    (let* ((prompt (buffer-string))
+           (buf (current-buffer))
+           (response-buffer (if org-ai-on-project-use-stream
+                                (org-ai-prompt prompt
+                                               :output-buffer (current-buffer)
+                                               :callback (lambda ()
+                                                           (with-current-buffer buf
+                                                             (org-ai-on-project--request-cleanup))))
+                              (org-ai-chat-request
+                               :messages (org-ai--collect-chat-messages prompt)
+                               :model org-ai-default-chat-model
+                               :callback (lambda (content role usage)
+                                           (with-current-buffer buf
+                                             (save-excursion
+                                               (insert content))
+                                             (org-ai-on-project--request-cleanup)))))))
+
+      (setq org-ai-on-project--current-request-in-progress
+            (make-org-ai-on-project--request-in-progress
+             :state state
+             :start-pos (point)
+             :spinner (spinner-start 'progress-bar)
+             :url-response-buffer response-buffer))))))
+
+(defun org-ai-on-project--request-cleanup ()
+  ""
+  (when-let (current org-ai-on-project--current-request-in-progress)
+    (spinner-stop)
+    ;; (display-buffer (org-ai-on-project--request-in-progress-url-response-buffer current))
+    (unless org-ai-on-project-use-stream
+      (kill-buffer (org-ai-on-project--request-in-progress-url-response-buffer current)))
+    ;;(setq org-ai-on-project--current-request-in-progress nil)
+    ))
+
+
+
+(comment
+  org-ai-on-project--current-request-in-progress
+
+  (with-current-buffer "*org-ai-on-project-result*"
+    (let ((pos (org-ai-on-project--request-in-progress-start-pos org-ai-on-project--current-request-in-progress)))
+      (goto-char pos)
+      (let ((modified (org-ai-on-project--extract-files-and-code-blocks))
+            (original-and-modified-files (make-hash-table :test 'equal)))
+        (cl-loop for key being the hash-keys of modified
+                 using (hash-values value)
+                 ;; for each file, create a __org-ai__ file that contains the modified content
+                 do (let ((modified-file (replace-regexp-in-string "\\(.*/\\)?\\(.*\\)" "\\1__org-ai__\\2" key)))
+                      (puthash key modified-file original-and-modified-files)
+                      (with-temp-file modified-file
+                        (insert value))))
+        (setq xxx original-and-modified-files))))
+
+
+  (hash-table-keys xxx)
+  (gethash "test.js" xxx)
+
+  (ediff-merge-files "test.js" "__org-ai__test.js")
+  (setq file "foo/bar/baz.org")
+  (setq file "baz.org"))
+
+
+
 
 ;;;###autoload
 (defun org-ai-on-project (&optional base-dir)

--- a/org-ai-openai.el
+++ b/org-ai-openai.el
@@ -99,8 +99,13 @@ messages."
 
 (defvar org-ai-openai-completion-endpoint "https://api.openai.com/v1/completions")
 
+(defvar org-ai--current-request-buffer-for-stream nil
+  "Internal var that stores the current request buffer.
+For stream responses.")
+
 (defvar org-ai--current-request-buffer nil
-  "Internal var that stores the current request buffer.")
+  "Internal var that stores the current request buffer.
+For chat completion responses.")
 
 (defvar org-ai--current-request-callback nil
   "Internal var that stores the current request callback.")
@@ -273,51 +278,119 @@ penalty. `PRESENCE-PENALTY' is the presence penalty."
 					    :temperature temperature
 					    :top-p top-p
 					    :frequency-penalty frequency-penalty
-					    :presence-penalty presence-penalty)))
+					    :presence-penalty presence-penalty
+                                            :stream t)))
 
-    ;; (message "REQUEST %s" url-request-data)
+    (message "REQUEST %s" url-request-data)
 
     (setq org-ai--current-request-callback callback)
+
+    (setq org-ai--current-request-buffer-for-stream
+          (url-retrieve
+           endpoint
+           (lambda (_events)
+             (org-ai--maybe-show-openai-request-error org-ai--current-request-buffer-for-stream)
+             (org-ai-reset-stream-state))))
+
+    ;; (display-buffer-use-some-window org-ai--current-request-buffer-for-stream nil)
+
+    (unless (member 'org-ai--url-request-on-change-function after-change-functions)
+      (with-current-buffer org-ai--current-request-buffer-for-stream
+        (add-hook 'after-change-functions #'org-ai--url-request-on-change-function nil t)))
+
+    org-ai--current-request-buffer-for-stream))
+
+(cl-defun org-ai-chat-request (&optional &key messages model max-tokens temperature top-p frequency-penalty presence-penalty callback)
+  "Send a request to the OpenAI API. Do not stream.
+`MESSAGES' is the query for chatgpt.
+`CALLBACK' is the callback function.
+`MODEL' is the model to use.
+`MAX-TOKENS' is the maximum number of tokens to generate.
+`TEMPERATURE' is the temperature of the distribution.
+`TOP-P' is the top-p value.
+`FREQUENCY-PENALTY' is the frequency penalty.
+`PRESENCE-PENALTY' is the presence penalty."
+  (unless org-ai-openai-api-token
+    (error "Please set `org-ai-openai-api-token' to your OpenAI API token"))
+  (let* ((token org-ai-openai-api-token)
+         (url-request-extra-headers `(("Authorization" . ,(encode-coding-string (string-join `("Bearer" ,token) " ") 'utf-8))
+                                      ("Content-Type" . "application/json")))
+         (url-request-method "POST")
+         (endpoint (if messages org-ai-openai-chat-endpoint org-ai-openai-completion-endpoint))
+         (url-request-data (org-ai--payload :messages messages
+					    :model model
+					    :max-tokens max-tokens
+					    :temperature temperature
+					    :top-p top-p
+					    :frequency-penalty frequency-penalty
+					    :presence-penalty presence-penalty
+                                            :stream nil)))
+
+    ;; (message "REQUEST %s" url-request-data)
 
     (setq org-ai--current-request-buffer
           (url-retrieve
            endpoint
            (lambda (_events)
-             (org-ai--maybe-show-openai-request-error)
-             (org-ai-reset-stream-state))))
+             (unless (org-ai--maybe-show-openai-request-error
+                      org-ai--current-request-buffer)
+               (when callback
+                 (with-current-buffer org-ai--current-request-buffer
+                   (condition-case err
+                       (progn (goto-char url-http-end-of-headers)
+                              (if-let* ((result (json-read))
+                                        (usage (alist-get 'usage result))
+                                        (choices (alist-get 'choices result))
+                                        (choice (aref choices 0))
+                                        (message (alist-get 'message choice))
+                                        (role (alist-get 'role message))
+                                        (content (alist-get 'content message)))
+                                  (funcall callback content role usage)
+                                (funcall callback nil nil nil)))
+                     (error (org-ai--show-error err)))))))))
 
-    ;; (display-buffer-use-some-window org-ai--current-request-buffer nil)
+    ;;(display-buffer-use-some-window org-ai--current-request-buffer nil)
 
-    (unless (member 'org-ai--url-request-on-change-function after-change-functions)
-      (with-current-buffer org-ai--current-request-buffer
-        (add-hook 'after-change-functions #'org-ai--url-request-on-change-function nil t)))))
+    org-ai--current-request-buffer))
 
+;; (org-ai-chat-request
+;;  :messages (org-ai--collect-chat-messages "Hello, how are you?")
+;;  :model "gpt-4"
+;;  :callback (lambda (content role usage)
+;;              (message "content: %s" content)
+;;              (message "ROLE: %s" role)
+;;              (message "USAGE: %s" usage)))
 
-(defun org-ai--maybe-show-openai-request-error ()
+(defun org-ai--maybe-show-openai-request-error (request-buffer)
   "If the API request returned an error, show it."
-  (with-current-buffer org-ai--current-request-buffer
+  (with-current-buffer request-buffer
     (when (and (boundp 'url-http-end-of-headers) url-http-end-of-headers)
       (goto-char url-http-end-of-headers))
     (condition-case nil
         (let* ((content (buffer-substring-no-properties (point) (point-max)))
                (body (json-read-from-string content)))
           (let* ((err (alist-get 'error body))
-                 (message (or (alist-get 'message err) (json-encode err)))
-                 (buf (get-buffer-create "*org-ai error*")))
-            ;; show error message
-            (with-current-buffer buf
-              (erase-buffer)
-              (insert message)
-              (pop-to-buffer buf)
-              (goto-char (point-min))
-              (toggle-truncate-lines -1)
-              (read-only-mode 1)
-              ;; close buffer when q is pressed
-              (local-set-key (kbd "q") (lambda () (interactive) (kill-buffer-and-window)))
-              t)))
+                 (message (or (alist-get 'message err) (json-encode err))))
+            (org-ai--show-error message)))
       (error nil))))
 
-(cl-defun org-ai--payload (&optional &key prompt messages model max-tokens temperature top-p frequency-penalty presence-penalty)
+(defun org-ai--show-error (error-message)
+  "Show an error message in a buffer."
+  (condition-case nil
+      (let ((buf (get-buffer-create "*org-ai error*")))
+        (with-current-buffer buf
+          (erase-buffer)
+          (insert message)
+          (pop-to-buffer buf)
+          (goto-char (point-min))
+          (toggle-truncate-lines -1)
+          (read-only-mode 1)
+          ;; close buffer when q is pressed
+          (local-set-key (kbd "q") (lambda () (interactive) (kill-buffer-and-window)))
+          t))
+    (error nil)))
+
+(cl-defun org-ai--payload (&optional &key prompt messages model max-tokens temperature top-p frequency-penalty presence-penalty stream)
   "Create the payload for the OpenAI API.
 `PROMPT' is the query for completions `MESSAGES' is the query for
 chatgpt. `MODEL' is the model to use. `MAX-TOKENS' is the
@@ -330,7 +403,7 @@ is the presence penalty."
          (data (map-filter (lambda (x _) x)
                            `(,input
                              (model . ,model)
-                             (stream . t)
+                             ,@(when stream            `((stream . ,stream)))
                              ,@(when max-tokens        `((max_tokens . ,max-tokens)))
                              ,@(when temperature       `((temperature . ,temperature)))
                              ,@(when top-p             `((top_p . ,top-p)))
@@ -343,7 +416,7 @@ is the presence penalty."
 Three arguments are passed to each function: the positions of
 the beginning and end of the range of changed text,
 and the length in chars of the pre-change text replaced by that range."
-  (with-current-buffer org-ai--current-request-buffer
+  (with-current-buffer org-ai--current-request-buffer-for-stream
     (when (and (boundp 'url-http-end-of-headers) url-http-end-of-headers)
       (save-excursion
         (if org-ai--url-buffer-last-position
@@ -391,17 +464,17 @@ and the length in chars of the pre-change text replaced by that range."
 (defun org-ai-interrupt-current-request ()
   "Interrupt the current request."
   (interactive)
-  (when (and org-ai--current-request-buffer (buffer-live-p org-ai--current-request-buffer))
+  (when (and org-ai--current-request-buffer-for-stream (buffer-live-p org-ai--current-request-buffer-for-stream))
     (let (kill-buffer-query-functions)
-      (kill-buffer org-ai--current-request-buffer))
-    (setq org-ai--current-request-buffer nil)
+      (kill-buffer org-ai--current-request-buffer-for-stream))
+    (setq org-ai--current-request-buffer-for-stream nil)
     (org-ai-reset-stream-state)))
 
 (defun org-ai-reset-stream-state ()
   "Reset the stream state."
   (interactive)
-  (when (and org-ai--current-request-buffer (buffer-live-p org-ai--current-request-buffer))
-    (with-current-buffer org-ai--current-request-buffer
+  (when (and org-ai--current-request-buffer-for-stream (buffer-live-p org-ai--current-request-buffer-for-stream))
+    (with-current-buffer org-ai--current-request-buffer-for-stream
       (remove-hook 'after-change-functions #'org-ai--url-request-on-change-function t)
       (setq org-ai--url-buffer-last-position nil)))
   (setq org-ai--current-request-callback nil)
@@ -411,8 +484,8 @@ and the length in chars of the pre-change text replaced by that range."
 (defun org-ai-open-request-buffer ()
   "A debug helper that opens the url request buffer."
   (interactive)
-  (when (buffer-live-p org-ai--current-request-buffer)
-    (pop-to-buffer org-ai--current-request-buffer)))
+  (when (buffer-live-p org-ai--current-request-buffer-for-stream)
+    (pop-to-buffer org-ai--current-request-buffer-for-stream)))
 
 (defun org-ai-switch-chat-model ()
   "Change `org-ai-default-chat-model'."

--- a/org-ai-useful.el
+++ b/org-ai-useful.el
@@ -183,9 +183,9 @@ argument and returns a prompt.
     (org-ai-prompt full-prompt :output-buffer output-buffer :callback callback)))
 
 
-(defun org-ai--insert-quote-prefix (str)
-  "Prepend all lines in `STR' with '>'."
-  (replace-regexp-in-string "^" "> " str))
+(defun org-ai--prefix-lines (str prefix)
+  "Prepend all lines in `STR' with `PREFIX'."
+  (replace-regexp-in-string "^" prefix str))
 
 (defun org-ai--prompt-on-region-create-text-prompt (user-input text)
   "Create a prompt for `org-ai-on-region'.
@@ -198,9 +198,9 @@ Here is the question:
 
 Here is the text:
 %s
-" (org-ai--insert-quote-prefix user-input) (org-ai--insert-quote-prefix text)))
+" (org-ai--prefix-lines user-input "    ") (org-ai--prefix-lines text "    ")))
 
-(defun org-ai--prompt-on-region-create-code-prompt (user-input text)
+(defun org-ai--prompt-on-region-create-code-prompt (user-input code)
   "Create a prompt for `org-ai-on-region'.
 `USER-INPUT' is the user input like a question to answer.
 `TEXT' is the code of the region."
@@ -211,7 +211,7 @@ Here is the question:
 
 Here is the code snippet:
 %s
-" (org-ai--insert-quote-prefix user-input) (org-ai--insert-quote-prefix text)))
+" user-input code))
 
 (defun org-ai-on-region (start end question &optional buffer-name text-kind)
   "Ask ChatGPT to answer a question based on the selected text.
@@ -284,9 +284,12 @@ Here is the instruction:
 %s
 
 Here is the code snippet:
+```
 %s
-" how (org-ai--insert-quote-prefix code))))
+```
+" how code)))
           (buffer-with-selected-code (current-buffer))
+          (file-name (buffer-file-name))
           (output-buffer (get-buffer-create "*org-ai-refactor*"))
           (win-config (current-window-configuration)))
       (org-ai--on-region-internal start end text-prompt-fn
@@ -302,7 +305,7 @@ Here is the code snippet:
                                                   (push-mark)
                                                   (push-mark (point-max) nil t)
                                                   (goto-char (point-min)))
-                                                (org-ai--diff-and-patch-buffers buffer-with-selected-code output-buffer)
+                                                (org-ai--diff-and-patch-buffers buffer-with-selected-code output-buffer file-name)
                                                 (set-window-configuration win-config)))))))
 
 (defun org-ai--diff-and-patch-buffers (buffer-a buffer-b &optional file-name)

--- a/org-ai-useful.el
+++ b/org-ai-useful.el
@@ -203,7 +203,7 @@ Here is the text:
 (defun org-ai--prompt-on-region-create-code-prompt (user-input code)
   "Create a prompt for `org-ai-on-region'.
 `USER-INPUT' is the user input like a question to answer.
-`TEXT' is the code of the region."
+`CODE' is the code of the region."
   (format "In the following I will show you a question and then a code snippet. I want you to answer that question based on the code snippet.
 
 Here is the question:
@@ -312,6 +312,7 @@ Here is the code snippet:
   "Will diff `BUFFER-A' and `BUFFER-B' and and offer to patch'.
 `BUFFER-A' is the first buffer.
 `BUFFER-B' is the second buffer.
+`FILE-NAME' is the optional name of the file to use in the diff buffer header.
 Will open the diff buffer and return it."
   (let* ((reg-A (with-current-buffer buffer-a
                   (cons (region-beginning) (region-end))))
@@ -342,6 +343,10 @@ Will open the diff buffer and return it."
 
 (defun org-ai--diff-rename-files (file-name-a file-name-b &optional diff-header-start)
   "Will rename the files of the first file block of a diff buffer.
+`FILE-NAME-A' is the name of the first file.
+`FILE-NAME-B' is the name of the second file.
+`DIFF-HEADER-START' is the start of the diff header, defaults to \"diff -u \".
+
 E.g. will rename file-a.txt and file-b.txt to the specified names.
     diff -u file-a.txt file-b.txt
     --- file-a.txt	2023-04-17 01:48:47
@@ -350,7 +355,7 @@ Note: This expects only hunks of a single file."
   (let ((diff-header-start (or diff-header-start "diff -u "))
         (inhibit-read-only t))
     (save-excursion
-      (let (start end file-name-1 file-name-2)
+      (let (start file-name-1 file-name-2)
         (goto-char (point-min))
         (search-forward diff-header-start)
 
@@ -361,9 +366,11 @@ Note: This expects only hunks of a single file."
         (list file-name-1 file-name-2)
 
         (goto-char (point-min))
-        (replace-string file-name-1 file-name-a)
+        (while (search-forward file-name-1 nil t)
+          (replace-match file-name-a))
         (goto-char (point-min))
-        (replace-string file-name-2 file-name-b)))))
+        (while (search-forward file-name-2 nil t)
+          (replace-match file-name-b))))))
 
 ;; (let ((buffer-with-selected-code (current-buffer))
 ;;       (output-buffer (get-buffer-create "*org-ai-refactor*")))

--- a/org-ai.el
+++ b/org-ai.el
@@ -137,6 +137,8 @@ It's designed to \"do the right thing\":
              org-ai-talk--reading-process
              (process-live-p org-ai-talk--reading-process))
         (org-ai-talk-stop))
+       (org-ai--current-request-buffer-for-stream
+        (org-ai-interrupt-current-request))
        (org-ai--current-request-buffer
         (org-ai-interrupt-current-request)))
     (error nil)))


### PR DESCRIPTION
This adds a new command, `org-ai-on-project` which creates an interactive buffer to run prompts on multiple files / a project and allows to guide modifications that are then done by the AI model.

This implements the ideas from: https://github.com/rksm/org-ai/issues/20