### PR TITLE
Support noweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ _Note: In order to use this you'll need an [OpenAI account](https://platform.ope
     - [Image variation](#image-variation)
     - [Global Commands](#global-commands)
         - [org-ai-on-project](#org-ai-on-project)
+    - [Noweb Support] (#noweb-support)
 - [Installation](#installation)
     - [Melpa](#melpa)
     - [Straight.el](#straightel)
@@ -96,20 +97,20 @@ This will result in an API payload like
 ```json
 {
   "messages": [
-    {
-      "role": "system",
-      "content": "Act as if you are a powerful medival king."
-    },
-    {
-      "role": "user",
-      "content": "What will you eat today?"
-    }
-  ],
+               {
+                 "role": "system",
+                 "content": "Act as if you are a powerful medival king."}
+               ,
+               {
+                 "role": "user",
+                 "content": "What will you eat today?"}]
+    
+  ,
   "model": "gpt-3.5-turbo",
   "stream": true,
   "max_tokens": 250,
-  "temperature": 1.2
-}
+  "temperature": 1.2}
+
 ```
 
 For some prompt ideas see for example [Awesome ChatGPT Prompts](https://github.com/f/awesome-chatgpt-prompts).
@@ -211,6 +212,39 @@ If you deactivate "modify code", the effect is similar to running `org-ai-on-reg
 
 With "modify code" activated, you can ask the AI to modify or refactor the code. By default ("Request diffs") deactivated, we will prompt to generate the new code for all selected files/regions and you can then see a diff per file and decide to apply it or not. With "Request diffs" active, the AI will be asked to directly create a unified diff that can then be applied. This is experimental and might not work. GPT can't count...
 
+### Noweb Support
+
+With `:noweb yes`
+
+```
+#+begin_ai 
+[SYS]: You are a mimic. Whenever I say something, repeat back what I say to you. Say exactly what I said, do not add anything.
+
+[ME]: <<sayhi()>>
+
+
+[AI]: <<sayhi()>>
+
+[ME]: 
+#+end_ai
+
+#+begin_ai :noweb yes
+[SYS]: You are a mimic. Whenever I say something, repeat back what I say to you. Say exactly what I said, do not add anything.
+
+[ME]: <<sayhi()>>
+
+
+[AI]: Hello there.
+
+[ME]: 
+#+end_ai
+
+#+name: sayhi
+#+begin_src shell 
+echo "Hello there"
+#+end_src
+```
+
 ## Installation
 
 ### Melpa
@@ -235,8 +269,8 @@ you can install it with:
   (org-ai-global-mode) ; installs global keybindings on C-c M-a
   :config
   (setq org-ai-default-chat-model "gpt-4") ; if you are on the gpt-4 beta:
-  (org-ai-install-yasnippets) ; if you are using yasnippet and want `ai` snippets
-)
+  (org-ai-install-yasnippets)) ; if you are using yasnippet and want `ai` snippets
+
 ```
 
 ### Straight.el
@@ -261,9 +295,9 @@ Then, if you use `use-package`:
 
 ```elisp
 (use-package org-ai
-  :load-path (lambda () "path/to/org-ai")
+  :load-path (lambda () "path/to/org-ai"))
   ;; ...rest as above...
-  )
+  
 ```
 
 or just with `require`:

--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ Given a named source block
 echo "Hello there"
 #+end_src
 ```
-
 We can try to reference it by name, but it doesn't work.
 ```
 #+begin_ai 
@@ -234,9 +233,10 @@ We can try to reference it by name, but it doesn't work.
 
 [ME]: 
 #+end_ai
-
+```
 With `:noweb yes`
 
+```
 #+begin_ai :noweb yes
 [SYS]: You are a mimic. Whenever I say something, repeat back what I say to you. Say exactly what I said, do not add anything.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _Note: In order to use this you'll need an [OpenAI account](https://platform.ope
     - [Image variation](#image-variation)
     - [Global Commands](#global-commands)
         - [org-ai-on-project](#org-ai-on-project)
-    - [Noweb Support] (#noweb-support)
+    - [Noweb Support](#noweb-support)
 - [Installation](#installation)
     - [Melpa](#melpa)
     - [Straight.el](#straightel)

--- a/README.md
+++ b/README.md
@@ -214,8 +214,15 @@ With "modify code" activated, you can ask the AI to modify or refactor the code.
 
 ### Noweb Support
 
-With `:noweb yes`
+Given a named source block
+```
+#+name: sayhi
+#+begin_src shell 
+echo "Hello there"
+#+end_src
+```
 
+We can try to reference it by name, but it doesn't work.
 ```
 #+begin_ai 
 [SYS]: You are a mimic. Whenever I say something, repeat back what I say to you. Say exactly what I said, do not add anything.
@@ -228,6 +235,8 @@ With `:noweb yes`
 [ME]: 
 #+end_ai
 
+With `:noweb yes`
+
 #+begin_ai :noweb yes
 [SYS]: You are a mimic. Whenever I say something, repeat back what I say to you. Say exactly what I said, do not add anything.
 
@@ -238,12 +247,41 @@ With `:noweb yes`
 
 [ME]: 
 #+end_ai
+```
 
-#+name: sayhi
-#+begin_src shell 
-echo "Hello there"
+#### Run arbitrary lisp inline
+
+This is a hack but it works really well.
+
+Create a block
+
+```
+#+name: identity
+#+begin_src emacs-lisp :var x="fill me in"
+(format "%s" x)
 #+end_src
 ```
+
+We can invoke it and let noweb parameters (which support lisp) evaluate as code
+
+```
+#+begin_ai :noweb yes
+Tell me some 3, simple ways to improve this dockerfile
+
+<<identity(x=(quelpa-slurp-file "~/code/ibr-api/Dockerfile"))>>
+
+
+
+[AI]: 1. Use a more specific version of Python, such as "python:3.9.6-buster" instead of "python:3.9-buster", to ensure compatibility with future updates.
+
+2. Add a cleanup step after installing poetry to remove any unnecessary files or dependencies, thus reducing the size of the final image.
+
+3. Use multi-stage builds to separate the build environment from the production environment, thus reducing the size of the final image and increasing security. For example, the first stage can be used to install dependencies and build the code, while the second stage can contain only the final artifacts and be used for deployment.
+
+[ME]: 
+#+end_ai
+```
+
 
 ## Installation
 

--- a/org-ai.el
+++ b/org-ai.el
@@ -105,8 +105,11 @@ the text content to the OpenAI API and replace the block with the
 result."
   (interactive)
   (let* ((context (org-ai-special-block))
-         (content (org-ai-get-block-content context))
          (info (org-ai-get-block-info context))
+         (unexpanded-content (org-ai-get-block-content context))
+         (content (if (eq "yes" (plist-get :noweb info))
+                      (org-babel-expand-noweb-references (list "markdown" unexpanded-content))
+                      unexpanded-content))
          (req-type (org-ai--request-type info))
          (sys-prompt-for-all-messages (or (not (eql 'x (alist-get :sys-everywhere info 'x)))
                                           org-ai-default-inject-sys-prompt-for-all-messages)))

--- a/org-ai.el
+++ b/org-ai.el
@@ -107,7 +107,7 @@ result."
   (let* ((context (org-ai-special-block))
          (info (org-ai-get-block-info context))
          (unexpanded-content (org-ai-get-block-content context))
-         (content (if (eq "yes" (plist-get :noweb info))
+         (content (if (string-equal-ignore-case "yes" (alist-get :noweb info "no"))
                       (org-babel-expand-noweb-references (list "markdown" unexpanded-content))
                       unexpanded-content))
          (req-type (org-ai--request-type info))


### PR DESCRIPTION
I want to be able to template values into org-ai blocks and turns out pretty straightforward to add support for [noweb blocks](https://orgmode.org/manual/Noweb-Reference-Syntax.html).

README excerpt:
Given a named source block
```
#+name: sayhi
#+begin_src shell 
echo "Hello there"
#+end_src
```
We can try to reference it by name, but it doesn't work.
```
#+begin_ai 
[SYS]: You are a mimic. Whenever I say something, repeat back what I say to you. Say exactly what I said, do not add anything.

[ME]: <<sayhi()>>


[AI]: <<sayhi()>>

[ME]: 
#+end_ai
```
With `:noweb yes`

```
#+begin_ai :noweb yes
[SYS]: You are a mimic. Whenever I say something, repeat back what I say to you. Say exactly what I said, do not add anything.

[ME]: <<sayhi()>>


[AI]: Hello there.

[ME]: 
#+end_ai
```

