### PR TITLE
More noweb tools and Marking shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ With `:noweb yes`
 #+end_ai
 ```
 
+You can also trigger noweb expansion with an `org-ai-noweb: yes` heading proprty anywhere in the parent headings (header args takes precedence).
+
+To see what your document will expand to when sent to the api, run `org-ai-expand-block`.
+
 #### Run arbitrary lisp inline
 
 This is a hack but it works really well.

--- a/org-ai-block.el
+++ b/org-ai-block.el
@@ -52,8 +52,13 @@ key-value pairs."
 `CONTEXT' is the context of the special block."
   (let* ((context (or context (org-ai-special-block)))
          (content-start (org-element-property :contents-begin context))
-         (content-end (org-element-property :contents-end context)))
-    (string-trim (buffer-substring-no-properties content-start content-end))))
+         (content-end (org-element-property :contents-end context))
+         (unexpanded-content (string-trim (buffer-substring-no-properties content-start content-end)))
+         (content (if (string-equal-ignore-case "yes" (alist-get :noweb (org-ai-get-block-info context) "no"))
+                      (org-babel-expand-noweb-references (list "markdown" unexpanded-content))
+                      unexpanded-content)))
+
+    content))
 
 (defun org-ai--request-type (info)
   "Look at the header of the #+begin_ai...#+end_ai block.

--- a/org-ai-block.el
+++ b/org-ai-block.el
@@ -49,7 +49,10 @@ key-value pairs."
 
 (defun org-ai-get-block-content (&optional context)
   "Extracts the text content of the #+begin_ai...#+end_ai block.
-`CONTEXT' is the context of the special block."
+`CONTEXT' is the context of the special block.
+
+Will expand noweb templates if an 'org-ai-noweb' property or 'noweb' header arg is \"yes\""
+
   (let* ((context (or context (org-ai-special-block)))
          (content-start (org-element-property :contents-begin context))
          (content-end (org-element-property :contents-end context))

--- a/org-ai-block.el
+++ b/org-ai-block.el
@@ -54,10 +54,13 @@ key-value pairs."
          (content-start (org-element-property :contents-begin context))
          (content-end (org-element-property :contents-end context))
          (unexpanded-content (string-trim (buffer-substring-no-properties content-start content-end)))
-         (content (if (string-equal-ignore-case "yes" (alist-get :noweb (org-ai-get-block-info context) "no"))
+         (info (org-ai-get-block-info context))
+         (noweb-control (or (alist-get :noweb info nil)
+                            (org-entry-get (point) "org-ai-noweb" 1)
+                            "no"))
+         (content (if (string-equal-ignore-case "yes" noweb-control)
                       (org-babel-expand-noweb-references (list "markdown" unexpanded-content))
                       unexpanded-content)))
-
     content))
 
 (defun org-ai--request-type (info)

--- a/org-ai-useful.el
+++ b/org-ai-useful.el
@@ -464,6 +464,27 @@ Will open the diff buffer and return it."
           diff-buffer)))))
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; Marking blocks
+
+(defun org-ai-mark-block-contents ()
+  "Set the currently marked region to the contents of this org-ai block. Place point at beginning of contents."
+  (interactive)
+  (when-let* ((block-info (cadr (org-ai-special-block)))
+              (contents-begin (plist-get block-info :contents-begin))
+              (contents-end (plist-get block-info :contents-end)))
+    (goto-char contents-begin)
+    (set-mark contents-end)
+    (activate-mark)))
+
+(defun org-ai-mark-block-after-point ()
+  "Set the currently marked region to the contents of this org-ai block after point."
+  (interactive)
+  (when-let* ((block-info (cadr (org-ai-special-block)))
+              (contents-end (plist-get block-info :contents-end)))
+    (set-mark (- contents-end 1))
+    (activate-mark)))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 (provide 'org-ai-useful)
 

--- a/org-ai.el
+++ b/org-ai.el
@@ -106,10 +106,7 @@ result."
   (interactive)
   (let* ((context (org-ai-special-block))
          (info (org-ai-get-block-info context))
-         (unexpanded-content (org-ai-get-block-content context))
-         (content (if (string-equal-ignore-case "yes" (alist-get :noweb info "no"))
-                      (org-babel-expand-noweb-references (list "markdown" unexpanded-content))
-                      unexpanded-content))
+         (content (org-ai-get-block-content context))
          (req-type (org-ai--request-type info))
          (sys-prompt-for-all-messages (or (not (eql 'x (alist-get :sys-everywhere info 'x)))
                                           org-ai-default-inject-sys-prompt-for-all-messages)))
@@ -122,6 +119,17 @@ result."
                                               org-ai-default-chat-system-prompt
                                               sys-prompt-for-all-messages)
                                    :context context)))))
+
+(defun org-ai-expand-block (&optional context)
+  "Pop a temp buffer showing what the org-ai block expands to and what will be sent to the api."
+  (interactive)
+  (let* ((context (or context (org-ai-special-block)))
+         (expanded (org-ai-get-block-content context)))
+    (if (called-interactively-p 'any)
+        (let ((buf (get-buffer-create "*Org-Ai Preview*")))
+          (with-help-window buf (with-current-buffer buf
+                                  (insert expanded))))
+      expanded)))
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; keyboard quit


### PR DESCRIPTION
- Move noweb expansion into `org-ai-get-block-content` so that it can be used from outside of `org-ai-complete-block`. Document it.
- Add an ability to control noweb expansion via a heading PROPERTY 
- Add `org-ai-expand-block` so its easy to see what your noweb will expand to
- Add helper functions `org-ai-mark-block-contents` and `org-ai-mark-block-after-point`