### PR TITLE
Restore insertion of role token

### DIFF
--- a/org-ai-openai.el
+++ b/org-ai-openai.el
@@ -231,32 +231,29 @@ the response into."
                 (backward-char))
 
               ;; insert text
-              (if-let* ((choices (or (alist-get 'choices response)
-                                     (plist-get response 'choices)))
-                        (choice (aref choices 0))
-                        (delta (plist-get choice 'delta)))
+              (when-let* ((choices (or (alist-get 'choices response)
+                                       (plist-get response 'choices)))
+                          (choice (aref choices 0))
+                          (delta (plist-get choice 'delta)))
+                (when-let ((role (plist-get delta 'role)))
+                  (setq org-ai--current-chat-role role)
                   (cond
-                   ((plist-get delta 'role)
-                    (let ((role (plist-get delta 'role)))
-                      (progn
-                        (setq org-ai--current-chat-role role)
-                        (cond
-                         ((string= role "assistant")
-                          (insert "\n[AI]: "))
-                         ((string= role "user")
-                          (insert "\n[ME]: "))
-                         ((string= role "system")
-                          (insert "\n[SYS]: ")))
-                        (run-hook-with-args 'org-ai-after-chat-insertion-hook 'role role))))
-                   ((plist-get delta 'content)
-                    (let ((text (plist-get delta 'content)))
-                      (when (or org-ai--chat-got-first-response (not (string= (string-trim text) "")))
-                        (when (and (not org-ai--chat-got-first-response) (string-prefix-p "```" text))
-                          ;; start markdown codeblock responses on their own line
-                          (insert "\n"))
-                        (insert (decode-coding-string text 'utf-8))
-                        (run-hook-with-args 'org-ai-after-chat-insertion-hook 'text text))
-                      (setq org-ai--chat-got-first-response t)))))
+                   ((string= role "assistant")
+                    (insert "\n[AI]: "))
+                   ((string= role "user")
+                    (insert "\n[ME]: "))
+                   ((string= role "system")
+                    (insert "\n[SYS]: ")))
+                  (run-hook-with-args 'org-ai-after-chat-insertion-hook 'role role))
+
+                (let ((text (or (plist-get delta 'content) "")))
+                  (when (or org-ai--chat-got-first-response (not (string= (string-trim text) "")))
+                    (when (and (not org-ai--chat-got-first-response) (string-prefix-p "```" text))
+                      ;; start markdown codeblock responses on their own line
+                      (insert "\n"))
+                    (insert (decode-coding-string text 'utf-8))
+                    (run-hook-with-args 'org-ai-after-chat-insertion-hook 'text text))
+                  (setq org-ai--chat-got-first-response t)))
 
               (setq org-ai--current-insert-position-marker (point-marker))))))
 


### PR DESCRIPTION
This fixes the role insertion token issue. 
Because the API now returns an empty content string,
the cond branch to insert the role token was not getting 
triggered anymore. I removed it entirely, so as to always 
insert the content of the response, catching it missing.

Closes #60
