### PR TITLE
bug fix: if there is no [SYS] in the buffer, the default system prompt is not getting added

### DIFF
--- a/org-ai-block.el
+++ b/org-ai-block.el
@@ -227,7 +227,9 @@ intercalated. The [SYS] prompt used is either
                                        (push (list :role 'system :content sys-prompt) result)
                                        (push (list :role 'user :content content) result))
                                   finally return (reverse result))
-                       messages)))
+                       (if starts-with-sys-prompt-p
+                           messages
+                         (cons (list :role 'system :content sys-prompt) messages)))))
 
       (apply #'vector messages))))
 

--- a/org-ai-block.el
+++ b/org-ai-block.el
@@ -227,7 +227,7 @@ intercalated. The [SYS] prompt used is either
                                        (push (list :role 'system :content sys-prompt) result)
                                        (push (list :role 'user :content content) result))
                                   finally return (reverse result))
-                       (if starts-with-sys-prompt-p
+                       (if (or starts-with-sys-prompt-p (not sys-prompt))
                            messages
                          (cons (list :role 'system :content sys-prompt) messages)))))
 


### PR DESCRIPTION
This is probably a regression sometime ago. 

But right now, the default sys prompt is not getting added