### PR TITLE
Use `:login` to read the api key from the authinfo file

### DIFF
--- a/org-ai-openai.el
+++ b/org-ai-openai.el
@@ -54,7 +54,7 @@ Either from `org-ai-openai-api-token' or from auth-source."
   (or org-ai-openai-api-token
       (when org-ai-use-auth-source
         (require 'auth-source)
-        (auth-source-pick-first-password :host "api.openai.com" :user "org-ai"))
+        (auth-source-pick-first-password :host "api.openai.com" :login "org-ai"))
       (error "Please set `org-ai-openai-api-token' to your OpenAI API token or setup auth-source (see org-ai readme)")))
 
 (defcustom org-ai-default-completion-model "text-davinci-003"


### PR DESCRIPTION
With `:user`, the function `(auth-source-pick-first-password)` does not work for me.

The org-ai readme and the .netrc specs[*] both suggest `login`, so I'm guessing that `:user` here might be wrong.

I'm not expert, so please feel free to just close this MR if you feel that it's wrong :slightly_smiling_face: 

[*]
https://github.com/rksm/org-ai#openai-api-key
https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html