### PR TITLE
Support Org style workflow where properties can be specified in org file level or org header level

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ To apply syntax highlighted to your `#+begin_ai ...` blocks just add a language 
 The `#+begin_ai...#+end_ai` block can take the following options.
 
 ##### For ChatGPT
-By default, the content of ai blocks are interpreted as messages for ChatGPT. Text following `[ME]:` is associated with the user, text following `[AI]:` is associated as the model's response. Optionally you can start the block with a `[SYS]: <behahvior>` input to prime the model (see `org-ai-default-chat-system-prompt` below).
+By default, the content of ai blocks are interpreted as messages for ChatGPT. Text following `[ME]:` is associated with the user, text following `[AI]:` is associated as the model's response. Optionally you can start the block with a `[SYS]: <behavior>` input to prime the model (see `org-ai-default-chat-system-prompt` below).
 
 - `:max-tokens number` - number of maximum tokens to generate (default: nil, use OpenAI's default)
 - `:temperature number` - temperature of the model (default: 1)
@@ -153,6 +153,41 @@ By default, the content of ai blocks are interpreted as messages for ChatGPT. Te
 - `:frequency-penalty number` - frequency penalty of the model (default: 0)
 - `:presence-penalty` - presence penalty of the model (default: 0)
 - `:sys-everywhere` - repeat the system prompt for every user message (default: nil)
+
+If you have a lot of different threads of conversation regarding the same topic and settings (system prompt, temperature, etc) and you don't want to repeat all the options, you can set org file scope properties or create a org heading with property drawer, such that all `#+begin_ai...#+end_ai` blocks under that heading will inherit the settings.
+
+Examples:
+```org
+* Emacs (multiple conversations re emacs continue in this subtree)
+:PROPERTIES:
+:SYS: You are a emacs expert. You can help me by answering my questions. You can also ask me questions to clarify my intention.
+:temperature: 0.5
+:model: gpt-3.5-turbo
+:END:
+
+** Web programming via elisp
+#+begin_ai
+How to call a REST API and parse its JSON response?
+#+end_ai
+
+** Other emacs tasks
+#+begin_ai...#+end_ai
+
+* Python (multiple conversations re python continue in this subtree)
+:PROPERTIES:
+:SYS: You are a python programmer. Respond to the task with detailed step by step instructions and code.
+:temperature: 0.1
+:model: gpt-4
+:END:
+
+** Learning QUIC
+#+begin_ai
+How to setup a webserver with http3 support?
+#+end_ai
+
+** Other python tasks
+#+begin_ai...#+end_ai
+```
 
 The following custom variables can be used to configure the chat:
 

--- a/org-ai-openai.el
+++ b/org-ai-openai.el
@@ -209,17 +209,17 @@ penalty. `CONTEXT' is the context of the special block."
          (callback (if messages
                        (lambda (result) (org-ai--insert-chat-completion-response context buffer result))
                      (lambda (result) (org-ai--insert-stream-completion-response context buffer result)))))
-    (macrolet ((let-with-captured-arg-or-header-or-inherited-property
-                (definitions &rest body)
-                `(let ,(cl-loop for (sym . default-form) in definitions collect
-                                `(,sym (or ,sym
-                                           (alist-get ,(intern (format ":%s" (symbol-name sym))) info)
-                                           (when-let ((prop (org-entry-get-with-inheritance ,(symbol-name sym))))
-                                             (if (eq (quote ,sym) 'model)
-                                                 prop
-                                               (if (stringp prop) (string-to-number prop) prop)))
-                                           ,@default-form)))
-                   ,@body)))
+    (cl-macrolet ((let-with-captured-arg-or-header-or-inherited-property
+                    (definitions &rest body)
+                    `(let ,(cl-loop for (sym . default-form) in definitions collect
+                                    `(,sym (or ,sym
+                                               (alist-get ,(intern (format ":%s" (symbol-name sym))) info)
+                                               (when-let ((prop (org-entry-get-with-inheritance ,(symbol-name sym))))
+                                                 (if (eq (quote ,sym) 'model)
+                                                     prop
+                                                   (if (stringp prop) (string-to-number prop) prop)))
+                                               ,@default-form)))
+                       ,@body)))
       (let-with-captured-arg-or-header-or-inherited-property
        ((model (if messages org-ai-default-chat-model org-ai-default-completion-model))
         (max-tokens org-ai-default-max-tokens)

--- a/org-ai.el
+++ b/org-ai.el
@@ -113,7 +113,9 @@ result."
          (content (org-ai-get-block-content context))
          (req-type (org-ai--request-type info))
          (sys-prompt-for-all-messages (or (not (eql 'x (alist-get :sys-everywhere info 'x)))
-                                          org-ai-default-inject-sys-prompt-for-all-messages)))
+                                          (org-entry-get-with-inheritance "SYS-EVERYWHERE")
+                                          org-ai-default-inject-sys-prompt-for-all-messages))
+         (default-system-prompt (or (org-entry-get-with-inheritance "SYS") org-ai-default-chat-system-prompt)))
     (cl-case req-type
       (completion (org-ai-stream-completion :prompt content
                                             :context context))
@@ -121,12 +123,12 @@ result."
       (sd-image (org-ai-create-and-embed-sd context))
       (local-chat (org-ai-oobabooga-stream :messages (org-ai--collect-chat-messages
                                                       content
-                                                      org-ai-default-chat-system-prompt
+                                                      default-system-prompt
                                                       sys-prompt-for-all-messages)
                                            :context context))
       (t (org-ai-stream-completion :messages (org-ai--collect-chat-messages
                                               content
-                                              org-ai-default-chat-system-prompt
+                                              default-system-prompt
                                               sys-prompt-for-all-messages)
                                    :context context)))))
 


### PR DESCRIPTION
Hi,

Not sure if everyone has a die hard habit carried over from using org file in general where properties can be specified in org file level or org header level.

So SYS prompt, temperature etc can be set in file level or header level (see updated readme for example)

I find this makes org-ai fit perfectly into general org buffer workflow.