### PR TITLE
fix(org-ai-openai-image): make generating images work with Org 9.7

### DIFF
--- a/org-ai-openai-image.el
+++ b/org-ai-openai-image.el
@@ -231,7 +231,9 @@ object."
                                        (with-current-buffer buffer
                                          (save-excursion
                                            (let ((name (plist-get (cadr (org-ai-special-block)) :name))
-                                                 (contents-end (plist-get (cadr (org-ai-special-block)) :contents-end)))
+                                                 (contents-end (if (fboundp 'org-element-contents-end)
+                                                                   (org-element-contents-end (org-ai-special-block))
+                                                                 (plist-get (cadr (org-ai-special-block)) :contents-end))))
                                              (goto-char contents-end)
                                              (forward-line)
                                              (when name


### PR DESCRIPTION
Hi! Thanks for the package and all your work! Hoping I can help a tiny bit ;)

I've managed to fix https://github.com/rksm/org-ai/issues/64 - an issue with producing images on org 9.7. I am using Doom Emacs which ships org 9.7.

Haven't tested on older org versions unfortunately, but the fix is trivial, so should work (trivial to check if you have older org installed already).

The issue was that on Org 9.7 `(plist-get (cadr (org-ai-special-block)) :contents-end)` always produces nil,thus being useless & producing error on the next line (`goto-char`) 😉