### PR TITLE
Update default model to GPT-4o-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ This will result in an API payload like
       "content": "What will you eat today?"
     }
   ],
-  "model": "gpt-3.5-turbo",
+  "model": "gpt-4o-mini",
   "stream": true,
   "max_tokens": 250,
   "temperature": 1.2
@@ -203,7 +203,7 @@ Examples:
 :PROPERTIES:
 :SYS: You are a emacs expert. You can help me by answering my questions. You can also ask me questions to clarify my intention.
 :temperature: 0.5
-:model: gpt-3.5-turbo
+:model: gpt-4o-mini
 :END:
 
 ** Web programming via elisp
@@ -232,7 +232,7 @@ How to setup a webserver with http3 support?
 
 The following custom variables can be used to configure the chat:
 
-- `org-ai-default-chat-model` (default: `"gpt-3.5-turbo"`)
+- `org-ai-default-chat-model` (default: `"gpt-4o-mini"`)
 - `org-ai-default-max-tokens` How long the response should be. Currently cannot exceed 4096. If this value is too small an answer might be cut off (default: nil)
 - `org-ai-default-chat-system-prompt` How to "prime" the model. This is a prompt that is injected before the user's input. (default: `"You are a helpful assistant inside Emacs."`)
 - `org-ai-default-inject-sys-prompt-for-all-messages` Wether to repeat the system prompt for every user message. Sometimes the model "forgets" how it was primed. This can help remind it. (default: `nil`)

--- a/org-ai-openai.el
+++ b/org-ai-openai.el
@@ -63,16 +63,14 @@ in the `auth-sources' file."
   :type 'string
   :group 'org-ai)
 
-(defcustom org-ai-default-chat-model "gpt-3.5-turbo"
+(defcustom org-ai-default-chat-model "gpt-4o-mini"
   "The default model to use for chat-gpt requests. See https://platform.openai.com/docs/models for other options."
   :type 'string
   :group 'org-ai)
 
-(defcustom org-ai-chat-models '("gpt-3.5-turbo"
-                                "gpt-3.5-turbo-16k"
+(defcustom org-ai-chat-models '("gpt-4o-mini"
                                 "gpt-4"
                                 "gpt-4-32k"
-                                "gpt-4-vision-preview"
                                 "gpt-4-turbo"
                                 "gpt-4o")
   "Alist of available chat models. See https://platform.openai.com/docs/models."
@@ -352,7 +350,7 @@ from the OpenAI API."
   (type (:type org-ai--response-type))
   payload)
 
-;; Her is an example for how a full sequence of OpenAI responses looks like:
+;; Here is an example for how a full sequence of OpenAI responses looks like:
 ;; '((id "chatcmpl-9hM1UJgWe4cWKcJKvoMBzzebOOzli" object "chat.completion.chunk" created 1720119788 model "gpt-4o-2024-05-13" system_fingerprint "fp_d576307f90" choices [(index 0 delta (role "assistant" content "") logprobs nil finish_reason nil)])
 ;;   (id "chatcmpl-9hM1UJgWe4cWKcJKvoMBzzebOOzli" object "chat.completion.chunk" created 1720119788 model "gpt-4o-2024-05-13" system_fingerprint "fp_d576307f90" choices [(index 0 delta (content "Hello") logprobs nil finish_reason nil)])
 ;;   (id "chatcmpl-9hM1UJgWe4cWKcJKvoMBzzebOOzli" object "chat.completion.chunk" created 1720119788 model "gpt-4o-2024-05-13" system_fingerprint "fp_d576307f90" choices [(index 0 delta (content ",") logprobs nil finish_reason nil)])


### PR DESCRIPTION
this closes https://github.com/rksm/org-ai/issues/120

Per https://platform.openai.com/docs/models/gpt-3-5-turbo

> As of July 2024, gpt-4o-mini should be used in place of gpt-3.5-turbo,
as it is cheaper, more capable, multimodal, and just as fast. gpt-3.5-turbo is still available for use in the API.