### PR TITLE
support perplexity.ai responses in org-ai--normalize-response

### DIFF
--- a/org-ai-openai.el
+++ b/org-ai-openai.el
@@ -417,8 +417,6 @@ from the OpenAI API."
             (cl-loop for choice across choices
                      append (or (when-let ((role (plist-get (plist-get choice 'delta) 'role)))
                                   (list (make-org-ai--response :type 'role :payload role)))
-																(when-let ((role (plist-get (plist-get choice 'delta) 'content)))
-                                  (list (make-org-ai--response :type 'text :payload role)))
                                 (when-let ((content (plist-get (plist-get choice 'delta) 'content)))
                                   (list (make-org-ai--response :type 'text :payload content)))
                                 (when-let ((finish-reason (plist-get choice 'finish_reason)))

--- a/org-ai-openai.el
+++ b/org-ai-openai.el
@@ -417,6 +417,8 @@ from the OpenAI API."
             (cl-loop for choice across choices
                      append (or (when-let ((role (plist-get (plist-get choice 'delta) 'role)))
                                   (list (make-org-ai--response :type 'role :payload role)))
+																(when-let ((role (plist-get (plist-get choice 'delta) 'content)))
+                                  (list (make-org-ai--response :type 'text :payload role)))
                                 (when-let ((content (plist-get (plist-get choice 'delta) 'content)))
                                   (list (make-org-ai--response :type 'text :payload content)))
                                 (when-let ((finish-reason (plist-get choice 'finish_reason)))

--- a/org-ai-openai.el
+++ b/org-ai-openai.el
@@ -417,7 +417,7 @@ from the OpenAI API."
             (cl-loop for choice across choices
                      append (or (when-let ((role (plist-get (plist-get choice 'delta) 'role)))
                                   (list (make-org-ai--response :type 'role :payload role)))
-																(when-let ((role (plist-get (plist-get choice 'delta) 'content)))
+				(when-let ((role (plist-get (plist-get choice 'delta) 'content)))
                                   (list (make-org-ai--response :type 'text :payload role)))
                                 (when-let ((content (plist-get (plist-get choice 'delta) 'content)))
                                   (list (make-org-ai--response :type 'text :payload content)))


### PR DESCRIPTION
I was encountering a problem using the perplexity.ai service with org-ai. The requests and responses were working properly, but the response was not being written back to the buffer in the `#begin_ai  (...) #end_ai` block.

This PR updates the org-ai--normalize-response function to properly read the response from the `perplexity.ai` API.

Fixes:
- #119 