### PR TITLE
Add support for deepseek-chat and deepseek-reasoner models

### DIFF
--- a/org-ai-block.el
+++ b/org-ai-block.el
@@ -108,7 +108,7 @@ pairs from `org-ai-get-block-info'."
                       (save-excursion
                         (goto-char content-start)
                         (cl-loop with result
-                                 while (search-forward-regexp "\\[SYS\\]:\\|\\[ME\\]:\\|\\[AI\\]:" content-end t)
+                                 while (search-forward-regexp "\\[SYS\\]:\\|\\[ME\\]:\\|\\[AI\\]:\\|\\[AI_REASON\\]:" content-end t)
                                  do (push (match-beginning 0) result)
                                  finally return result)))))
         (if result
@@ -151,7 +151,7 @@ The numeric `ARG' can be used for killing the last n."
                   (kill-region end start)))))
 
 (defun org-ai--collect-chat-messages (content-string &optional default-system-prompt persistant-sys-prompts)
-  "Takes `CONTENT-STRING' and splits it by [SYS]:, [ME]: and [AI]: markers.
+  "Takes `CONTENT-STRING' and splits it by [SYS]:, [ME]:, [AI]: and [AI_REASON]: markers.
 If `PERSISTANT-SYS-PROMPTS' is non-nil, [SYS] prompts are
 intercalated. The [SYS] prompt used is either
 `DEFAULT-SYSTEM-PROMPT' or the first [SYS] prompt found in
@@ -162,7 +162,7 @@ intercalated. The [SYS] prompt used is either
     (goto-char (point-min))
 
     (let* (;; collect all positions before [ME]: and [AI]:
-           (sections (cl-loop while (search-forward-regexp "\\[SYS\\]:\\|\\[ME\\]:\\|\\[AI\\]:" nil t)
+           (sections (cl-loop while (search-forward-regexp "\\[SYS\\]:\\|\\[ME\\]:\\|\\[AI\\]:\\|\\[AI_REASON\\]:" nil t)
                               collect (save-excursion
                                         (goto-char (match-beginning 0))
                                         (point))))
@@ -181,13 +181,17 @@ intercalated. The [SYS] prompt used is either
            (parts (if (and
                        (not (string-prefix-p "[SYS]:" (car parts)))
                        (not (string-prefix-p "[ME]:" (car parts)))
-                       (not (string-prefix-p "[AI]:" (car parts))))
+                       (not (string-prefix-p "[AI]:" (car parts)))
+                       (not (string-prefix-p "[AI_REASON]:" (car parts))))
                       (progn (setf (car parts) (concat "[ME]: " (car parts)))
                              parts)
                     parts))
 
            ;; create (:role :content) list
            (messages (cl-loop for part in parts
+                              ;; Filter out reasoning parts as including them will cause 404
+                              ;; https://api-docs.deepseek.com/guides/reasoning_model#multi-round-conversation
+                              if (not (string= "[AI_REASON]" (car (split-string part ":"))))
                               collect (cl-destructuring-bind (type &rest content) (split-string part ":")
                                         (let ((type (string-trim type))
                                               (content (string-trim (string-join content ":"))))


### PR DESCRIPTION
I added a support for DeepSeek models. For the deepseek-chat model, there is nothing new. It's simply an OpenAI-compatible model which required no significant changes. Only had to move the `finish-reason` handler a bit above in `org-ai-openai.el` because DeepSeek sends and empty content at the end and for this reason we were not able to capture the `finish-reason` delta. Also removed the seemingly unnecessary handler:

```elisp
				(when-let ((role (plist-get (plist-get choice 'delta) 'content)))
                                  (list (make-org-ai--response :type 'text :payload role)))
```

as this and the next line was doing the exact same thing.

---

For deepseek-reasoner model I added the `[AI_REASON]` marker to be able to show and differentiate the reasoning tokens. Here is a chat example with the reasoner model, I think it's pretty self-explanatory:

```org
#+begin_ai markdown :model "deepseek-reasoner" :service "deepseek"
[ME]: Hello?

[AI_REASON]: Okay, the user said "Hello?" so I should respond in a friendly and welcoming manner. Since the user mentioned programming queries, I need to highlight that I can help with programming questions. Keep it short and to the point. Maybe add an emoji to keep it approachable. Let me make sure there's no unnecessary info. Just a quick greeting and an offer to assist.
[AI]: 👋 Hello! How can I assist you today? If you have any programming questions or need problem-solving help, I'm ready to provide quick, focused solutions.

[ME]: Hmm, ok

[AI_REASON]: Okay, the user initially greeted me, and I responded with a friendly hello, offering help especially with programming questions. Now they've replied with "Hmm, ok". I need to figure out how to respond appropriately.

First, their response is pretty vague. "Hmm, ok" could mean they're thinking, unsure, or maybe waiting for me to prompt them further. Since they haven't asked a specific question yet, my goal is to encourage them to elaborate so I can assist better.

I should make sure my reply is open and inviting. Maybe acknowledge their hesitation and ask for more details. It's important to be supportive and let them know I'm here to help with whatever they need. Perhaps provide examples of the types of questions I can answer, like specific programming problems, debugging, or algorithm advice. That might give them a clearer idea of how to frame their request.

Also, considering the user wants concise responses, I should keep it brief but still helpful. Avoid being too verbose but still cover possible angles. Maybe structure it with a friendly prompt followed by a few examples of common issues I can assist with. That way, if they're stuck, the examples might trigger what they need help with.

I need to make sure the tone remains approachable and not pushy. Phrases like "Feel free to share" or "What would you like help with?" can be effective. Also, using emojis might keep the conversation light, but since the previous response used one, maybe continue that to maintain consistency.

Another thought: maybe the user is testing how I handle non-specific responses. Ensuring that I handle this gracefully by prompting for more information without being repetitive is key. I should avoid assumptions and instead invite them to specify their needs.

In summary, my response should encourage the user to provide more details, offer examples of assistance areas, and maintain a friendly and supportive tone.
[AI]: 👋 Just let me know what you'd like help with! For example:
- Debugging a code snippet
- Algorithm optimization
- Framework-specific questions
- Code structure advice

**Quick start**: Share your goal or a code snippet, and I'll give a concise solution + pro tips when relevant. 😊
#+end_ai
```

As an implementation detail, I also had to introduce the buffer local variable `org-ai--currently-reasoning` because we need to keep some sort of state to understand when the reasoning ends and the real answer begins.

Let me know how this sounds. I tried a few different approaches but I believe this one simply fits the spirit of `org-ai`.
