### PR TITLE
Add `ai` block to `org-structure-template-alist`

### DIFF
--- a/org-ai-block.el
+++ b/org-ai-block.el
@@ -29,6 +29,9 @@
 (when (and (boundp 'org-protecting-blocks) (listp org-protecting-blocks))
   (add-to-list 'org-protecting-blocks "ai"))
 
+(when (boundp 'org-structure-template-alist)
+  (add-to-list 'org-structure-template-alist '("A" . "ai")))
+
 ;; `org-element-with-disabled-cache' is not available pre org-mode 9.6.6, i.e.
 ;; emacs 28 does not ship with it
 (defmacro org-ai--org-element-with-disabled-cache (&rest body)


### PR DESCRIPTION
Just a minor convenience addition. With this, users can utilize `org-insert-structure-template` to insert AI blocks and they can also use `<A` completion with org-tempo. Also it is useful to register AI blocks so that other packages like [corg.el](https://github.com/isamert/corg.el) can use this info to provide completion etc. (it does not work yet but I'm thinking of adding such completions to corg.el)