### PR TITLE
fix: openai parameterization errors

### DIFF
--- a/org-ai-openai.el
+++ b/org-ai-openai.el
@@ -715,12 +715,12 @@ is the presence penalty.
 
     ;; o1 models currently does not support system prompt
     (when (and (or (eq service 'openai) (eq service 'azure-openai))
-               (or (string-prefix-p "o1" model) (string-prefix-p "o3" model)))
+               (string-prefix-p "o" model))
       (setq messages (cl-remove-if (lambda (msg) (string-equal (plist-get msg :role) "system")) messages))
       ;; o1 does not support max-tokens
       (when max-tokens
-        (setq max-tokens nil)
-        (setq max-completion-tokens (or max-tokens 128000))))
+        (setq max-completion-tokens (or max-tokens 128000))
+	(setq max-tokens nil)))
 
    (let* ((input (if messages `(messages . ,messages) `(prompt . ,prompt)))
           ;; TODO yet unsupported properties: n, stop, logit_bias, user
@@ -729,7 +729,7 @@ is the presence penalty.
                               (model . ,model)
                               ,@(when stream                `((stream . ,stream)))
                               ,@(when max-tokens            `((max_tokens . ,max-tokens)))
-                              ,@(when max-completion-tokens `((max-completion-tokens . ,max-completion-tokens)))
+                              ,@(when max-completion-tokens `((max_completion_tokens . ,max-completion-tokens)))
                               ,@(when temperature           `((temperature . ,temperature)))
                               ,@(when top-p                 `((top_p . ,top-p)))
                               ,@(when frequency-penalty     `((frequency_penalty . ,frequency-penalty)))


### PR DESCRIPTION
Use value of max-tokens before setting it to nil, rather than the other way around.

Replace `max-completion-tokens' with `max_completion_tokens` in parameters to openai API.

Expand use of `max_completion_tokens' parameter to all o-series models, rather than merely o1 and o3.

---

These are the minimal changes to fix the openai module. More broadly, it looks like `max_tokens` has been deprecated in favor of `max_completion_tokens` according to the [API docs](https://platform.openai.com/docs/api-reference/responses-streaming/response/web_search_call/completed). Maybe the whole section needs a bit of a rewrite if this is in fact the case?